### PR TITLE
Fixed matchStates reference error in FTA display.

### DIFF
--- a/templates/fta_display.html
+++ b/templates/fta_display.html
@@ -43,6 +43,7 @@
 </div>
 {{end}}
 {{define "script"}}
+<script src="/static/js/match_timing.js"></script>
 <script src="/static/js/fta_display.js"></script>
 {{end}}
 {{define "ftaTeam"}}


### PR DESCRIPTION
When I run the FTA display page during a match, I get this error in the browser's console:

`Uncaught ReferenceError: matchStates is not defined fta_display.js:24`

It breaks when it tries to look up something in the matchState dictionary, because it is defined in match_timing.js, which isn't included in the fta_display.html template.  Including that js file fixes the issue and makes the display work.
