### PR TITLE
Use FRC Events API for team info

### DIFF
--- a/db/migrations/20150324201112_AddFRCEventsAPIColumns.sql
+++ b/db/migrations/20150324201112_AddFRCEventsAPIColumns.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE event_settings ADD COLUMN fmsapidownloadenabled BOOLEAN;
+ALTER TABLE event_settings ADD COLUMN fmsapiusername VARCHAR(255);
+ALTER TABLE event_settings ADD COLUMN fmsapiauthkey VARCHAR(255);

--- a/db/migrations/20150324201112_AddFRCEventsAPIColumns.sql
+++ b/db/migrations/20150324201112_AddFRCEventsAPIColumns.sql
@@ -1,4 +1,0 @@
--- +goose Up
-ALTER TABLE event_settings ADD COLUMN fmsapidownloadenabled BOOLEAN;
-ALTER TABLE event_settings ADD COLUMN fmsapiusername VARCHAR(255);
-ALTER TABLE event_settings ADD COLUMN fmsapiauthkey VARCHAR(255);

--- a/db/migrations/20150401132914_AddTBAColumns.sql
+++ b/db/migrations/20150401132914_AddTBAColumns.sql
@@ -1,0 +1,3 @@
+-- +goose Up
+ALTER TABLE event_settings ADD COLUMN tbadownloadenabled BOOLEAN;
+ALTER TABLE event_settings ADD COLUMN tbaawardsdownloadenabled BOOLEAN;

--- a/event_settings.go
+++ b/event_settings.go
@@ -6,29 +6,28 @@
 package main
 
 type EventSettings struct {
-	Id                      int
-	Name                    string
-	Code                    string
-	DisplayBackgroundColor  string
-	NumElimAlliances        int
-	SelectionRound2Order    string
-	SelectionRound3Order    string
-	FMSAPIDownloadEnabled bool
-	FMSAPIUsername string
-	FMSAPIAuthKey string
-	AllianceDisplayHotGoals bool
-	RedGoalLightsAddress    string
-	BlueGoalLightsAddress   string
-	TbaPublishingEnabled    bool
-	TbaEventCode            string
-	TbaSecretId             string
-	TbaSecret               string
-	NetworkSecurityEnabled  bool
-	ApAddress               string
-	ApUsername              string
-	ApPassword              string
-	SwitchAddress           string
-	SwitchPassword          string
+	Id                       int
+	Name                     string
+	Code                     string
+	DisplayBackgroundColor   string
+	NumElimAlliances         int
+	SelectionRound2Order     string
+	SelectionRound3Order     string
+	TBADownloadEnabled       bool
+	TBAAwardsDownloadEnabled bool
+	AllianceDisplayHotGoals  bool
+	RedGoalLightsAddress     string
+	BlueGoalLightsAddress    string
+	TbaPublishingEnabled     bool
+	TbaEventCode             string
+	TbaSecretId              string
+	TbaSecret                string
+	NetworkSecurityEnabled   bool
+	ApAddress                string
+	ApUsername               string
+	ApPassword               string
+	SwitchAddress            string
+	SwitchPassword           string
 }
 
 const eventSettingsId = 0
@@ -44,7 +43,8 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		eventSettings.NumElimAlliances = 8
 		eventSettings.SelectionRound2Order = "L"
 		eventSettings.SelectionRound3Order = ""
-		eventSettings.FMSAPIDownloadEnabled = false
+		eventSettings.TBADownloadEnabled = true
+		eventSettings.TBAAwardsDownloadEnabled = true
 		err = database.eventSettingsMap.Insert(eventSettings)
 		if err != nil {
 			return nil, err

--- a/event_settings.go
+++ b/event_settings.go
@@ -13,7 +13,9 @@ type EventSettings struct {
 	NumElimAlliances        int
 	SelectionRound2Order    string
 	SelectionRound3Order    string
-	TeamInfoDownloadEnabled bool
+	FMSAPIDownloadEnabled bool
+	FMSAPIUsername string
+	FMSAPIAuthKey string
 	AllianceDisplayHotGoals bool
 	RedGoalLightsAddress    string
 	BlueGoalLightsAddress   string
@@ -42,7 +44,7 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		eventSettings.NumElimAlliances = 8
 		eventSettings.SelectionRound2Order = "L"
 		eventSettings.SelectionRound3Order = ""
-		eventSettings.TeamInfoDownloadEnabled = true
+		eventSettings.FMSAPIDownloadEnabled = false
 		err = database.eventSettingsMap.Insert(eventSettings)
 		if err != nil {
 			return nil, err

--- a/event_settings_test.go
+++ b/event_settings_test.go
@@ -19,7 +19,7 @@ func TestEventSettingsReadWrite(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, EventSettings{Id: 0, Name: "Untitled Event", Code: "UE", DisplayBackgroundColor: "#00ff00",
 		NumElimAlliances: 8, SelectionRound2Order: "L", SelectionRound3Order: "",
-		TeamInfoDownloadEnabled: true}, *eventSettings)
+		FMSAPIDownloadEnabled: false}, *eventSettings)
 
 	eventSettings.Name = "Chezy Champs"
 	eventSettings.Code = "cc"

--- a/event_settings_test.go
+++ b/event_settings_test.go
@@ -19,7 +19,7 @@ func TestEventSettingsReadWrite(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, EventSettings{Id: 0, Name: "Untitled Event", Code: "UE", DisplayBackgroundColor: "#00ff00",
 		NumElimAlliances: 8, SelectionRound2Order: "L", SelectionRound3Order: "",
-		FMSAPIDownloadEnabled: false}, *eventSettings)
+		TBADownloadEnabled: true, TBAAwardsDownloadEnabled: true}, *eventSettings)
 
 	eventSettings.Name = "Chezy Champs"
 	eventSettings.Code = "cc"

--- a/reports.go
+++ b/reports.go
@@ -6,9 +6,9 @@
 package main
 
 import (
-	"code.google.com/p/gofpdf"
 	"fmt"
 	"github.com/gorilla/mux"
+	"github.com/jung-kurt/gofpdf"
 	"net/http"
 	"strconv"
 	"text/template"

--- a/setup_settings.go
+++ b/setup_settings.go
@@ -42,7 +42,9 @@ func SettingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.NumElimAlliances = numAlliances
 	eventSettings.SelectionRound2Order = r.PostFormValue("selectionRound2Order")
 	eventSettings.SelectionRound3Order = r.PostFormValue("selectionRound3Order")
-	eventSettings.TeamInfoDownloadEnabled = r.PostFormValue("teamInfoDownloadEnabled") == "on"
+	eventSettings.FMSAPIDownloadEnabled = r.PostFormValue("FMSAPIDownloadEnabled") == "on"
+	eventSettings.FMSAPIUsername = r.PostFormValue("FMSAPIUsername")
+	eventSettings.FMSAPIAuthKey = r.PostFormValue("FMSAPIAuthKey")
 	eventSettings.AllianceDisplayHotGoals = r.PostFormValue("allianceDisplayHotGoals") == "on"
 	eventSettings.RedGoalLightsAddress = r.PostFormValue("redGoalLightsAddress")
 	eventSettings.BlueGoalLightsAddress = r.PostFormValue("blueGoalLightsAddress")

--- a/setup_settings.go
+++ b/setup_settings.go
@@ -42,9 +42,8 @@ func SettingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.NumElimAlliances = numAlliances
 	eventSettings.SelectionRound2Order = r.PostFormValue("selectionRound2Order")
 	eventSettings.SelectionRound3Order = r.PostFormValue("selectionRound3Order")
-	eventSettings.FMSAPIDownloadEnabled = r.PostFormValue("FMSAPIDownloadEnabled") == "on"
-	eventSettings.FMSAPIUsername = r.PostFormValue("FMSAPIUsername")
-	eventSettings.FMSAPIAuthKey = r.PostFormValue("FMSAPIAuthKey")
+	eventSettings.TBADownloadEnabled = r.PostFormValue("TBADownloadEnabled") == "on"
+	eventSettings.TBAAwardsDownloadEnabled = r.PostFormValue("TBAAwardsDownloadEnabled") == "on"
 	eventSettings.AllianceDisplayHotGoals = r.PostFormValue("allianceDisplayHotGoals") == "on"
 	eventSettings.RedGoalLightsAddress = r.PostFormValue("redGoalLightsAddress")
 	eventSettings.BlueGoalLightsAddress = r.PostFormValue("blueGoalLightsAddress")

--- a/setup_teams.go
+++ b/setup_teams.go
@@ -6,15 +6,15 @@
 package main
 
 import (
-	"fmt"
-	"time"
 	"bytes"
+	"fmt"
 	"github.com/dchest/uniuri"
 	"github.com/gorilla/mux"
 	"html/template"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const wpaKeyLength = 8
@@ -231,42 +231,42 @@ func canModifyTeamList() bool {
 
 // Returns the data for the given team number.
 func getOfficialTeamInfo(teamId int) (*Team, error) {
-  // Create the team variable that stores the result
-  var team Team
-    
-  // If team info download is enabled, download the current teams data (caching isn't easy with the new paging system in the api)
+	// Create the team variable that stores the result
+	var team Team
+
+	// If team info download is enabled, download the current teams data (caching isn't easy with the new paging system in the api)
 	if eventSettings.TBADownloadEnabled {
-	  var tbaTeam *TbaTeam = getTeamFromTba(teamId)
-		
+		var tbaTeam *TbaTeam = getTeamFromTba(teamId)
+
 		// Check if the result is valid.  If a team is not found, just return a basic team
-    if tbaTeam == nil {
-      team = Team{Id: teamId}
-      return &team, nil
-    }
-    
-    var recentAwards []TbaAward;
-    if eventSettings.TBAAwardsDownloadEnabled {
-	    recentAwards = getTeamAwardsFromTba(teamId)
-	  }
-    
-    var accomplishmentsBuffer bytes.Buffer
+		if tbaTeam == nil {
+			team = Team{Id: teamId}
+			return &team, nil
+		}
 
-    // Generate accomplishments string
-    for _, award := range recentAwards {
-      if time.Now().Year() - award.Year <= 2 {
-        accomplishmentsBuffer.WriteString(fmt.Sprint(award.Year, " - ", award.Name, "\n"))
-      }
-  	}
+		var recentAwards []TbaAward
+		if eventSettings.TBAAwardsDownloadEnabled {
+			recentAwards = getTeamAwardsFromTba(teamId)
+		}
 
-    // Use those variables to make a team object
-    team = Team{Id: teamId, Name: tbaTeam.Name, Nickname: tbaTeam.Nickname,
-    	City: tbaTeam.Locality, StateProv: tbaTeam.Reigon,
-    	Country: tbaTeam.Country, RookieYear: tbaTeam.RookieYear, Accomplishments: accomplishmentsBuffer.String()}
-  } else {
-    // If team grab is disabled, just use the team number
-    team = Team{Id: teamId}
-  }
-	
+		var accomplishmentsBuffer bytes.Buffer
+
+		// Generate accomplishments string
+		for _, award := range recentAwards {
+			if time.Now().Year()-award.Year <= 2 {
+				accomplishmentsBuffer.WriteString(fmt.Sprint(award.Year, " - ", award.Name, "\n"))
+			}
+		}
+
+		// Use those variables to make a team object
+		team = Team{Id: teamId, Name: tbaTeam.Name, Nickname: tbaTeam.Nickname,
+			City: tbaTeam.Locality, StateProv: tbaTeam.Reigon,
+			Country: tbaTeam.Country, RookieYear: tbaTeam.RookieYear, Accomplishments: accomplishmentsBuffer.String()}
+	} else {
+		// If team grab is disabled, just use the team number
+		team = Team{Id: teamId}
+	}
+
 	// Return the team object
 	return &team, nil
 }

--- a/setup_teams.go
+++ b/setup_teams.go
@@ -17,18 +17,6 @@ import (
 	"strings"
 )
 
-type TeamListings struct {
-    NumberOfTeams int `json:"teamCountTotal"`
-    Teams []JSONTeam `json:"teams"`
- }
-
-type JSONTeam struct {
-        ShortName string `json:"nameShort"`
-        TeamNumber string   `json:"teamNumber"`
-        LongName string   `json:"nameFull"`
-        City string   `json:"city"`
- }
-
 const wpaKeyLength = 8
 
 var officialTeamInfoUrl = "https://frc-api.usfirst.org/api/v1.0/teams/2015"

--- a/tba.go
+++ b/tba.go
@@ -17,6 +17,8 @@ import (
 
 var tbaBaseUrl = "http://www.thebluealliance.com"
 
+// MODELS
+
 type TbaMatch struct {
 	CompLevel      string                       `json:"comp_level"`
 	SetNumber      int                          `json:"set_number"`
@@ -48,6 +50,65 @@ type TbaRanking struct {
 	TrussCatch int `json:"T&C"`
 	GoalFoul   int `json:"G&F"`
 }
+
+type TbaTeam struct {
+  Website    string `json:"website"`
+  Name       string `json:"name"`
+  Locality   string `json:"locality"`
+  RookieYear int    `json:"rookie_year"`
+  Reigon     string `json:"region"`
+  TeamNumber int    `json:"team_number"`
+  Location   string `json:"location"`
+  Key        string `json:"key"`
+  Country    string `json:"country_name"`
+  Nickname   string `json:"nickname"`
+}
+
+type TbaAward struct {
+  Name       string `json:"name"`
+  EventKey   string `json:"event_key"`
+  Year       int    `json:"year"`
+  AwardType  int    `json:"award_type"`
+}
+
+// DATA RETRIEVAL
+func getTeamFromTba(teamNumber int) (*TbaTeam) {
+  url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)))
+  resp, _ := getTbaRequest(url);
+  
+
+  // Get the response and handle errors
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	
+	var teamData TbaTeam
+  json.Unmarshal(body, &teamData)
+  
+  return &teamData
+}
+
+func getTeamAwardsFromTba(teamNumber int) ([]TbaAward) {
+  url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)), "/history/awards")
+  resp, _ := getTbaRequest(url);
+  
+
+  // Get the response and handle errors
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	
+	var awardData []TbaAward
+  json.Unmarshal(body, &awardData)
+  
+  return awardData
+}
+
+// PUBLISHING
 
 // Uploads the event team list to The Blue Alliance.
 func PublishTeams() error {
@@ -213,6 +274,8 @@ func getTbaTeam(team int) string {
 	return fmt.Sprintf("frc%d", team)
 }
 
+// HELPERS
+
 // Signs the request and sends it to the TBA API.
 func postTbaRequest(resource string, body []byte) (*http.Response, error) {
 	path := fmt.Sprintf("/api/trusted/v1/event/%s/%s/update", eventSettings.TbaEventCode, resource)
@@ -226,4 +289,16 @@ func postTbaRequest(resource string, body []byte) (*http.Response, error) {
 	request.Header.Add("X-TBA-Auth-Id", eventSettings.TbaSecretId)
 	request.Header.Add("X-TBA-Auth-Sig", signature)
 	return client.Do(request)
+}
+
+// Sends a GET request to the TBA API
+func getTbaRequest(path string) (*http.Response, error) {
+  // Make an HTTP GET request with the TBA auth headers
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", fmt.Sprint(tbaBaseUrl, path), nil)
+	if err != nil {
+	  return nil, err
+	}
+	req.Header.Set("X-TBA-App-Id", "cheesy-arena:cheesy-fms:v0.1")
+  return client.Do(req)
 }

--- a/tba.go
+++ b/tba.go
@@ -52,60 +52,58 @@ type TbaRanking struct {
 }
 
 type TbaTeam struct {
-  Website    string `json:"website"`
-  Name       string `json:"name"`
-  Locality   string `json:"locality"`
-  RookieYear int    `json:"rookie_year"`
-  Reigon     string `json:"region"`
-  TeamNumber int    `json:"team_number"`
-  Location   string `json:"location"`
-  Key        string `json:"key"`
-  Country    string `json:"country_name"`
-  Nickname   string `json:"nickname"`
+	Website    string `json:"website"`
+	Name       string `json:"name"`
+	Locality   string `json:"locality"`
+	RookieYear int    `json:"rookie_year"`
+	Reigon     string `json:"region"`
+	TeamNumber int    `json:"team_number"`
+	Location   string `json:"location"`
+	Key        string `json:"key"`
+	Country    string `json:"country_name"`
+	Nickname   string `json:"nickname"`
 }
 
 type TbaAward struct {
-  Name       string `json:"name"`
-  EventKey   string `json:"event_key"`
-  Year       int    `json:"year"`
-  AwardType  int    `json:"award_type"`
+	Name      string `json:"name"`
+	EventKey  string `json:"event_key"`
+	Year      int    `json:"year"`
+	AwardType int    `json:"award_type"`
 }
 
 // DATA RETRIEVAL
-func getTeamFromTba(teamNumber int) (*TbaTeam) {
-  url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)))
-  resp, _ := getTbaRequest(url);
-  
+func getTeamFromTba(teamNumber int) *TbaTeam {
+	url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)))
+	resp, _ := getTbaRequest(url)
 
-  // Get the response and handle errors
+	// Get the response and handle errors
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil
 	}
-	
+
 	var teamData TbaTeam
-  json.Unmarshal(body, &teamData)
-  
-  return &teamData
+	json.Unmarshal(body, &teamData)
+
+	return &teamData
 }
 
-func getTeamAwardsFromTba(teamNumber int) ([]TbaAward) {
-  url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)), "/history/awards")
-  resp, _ := getTbaRequest(url);
-  
+func getTeamAwardsFromTba(teamNumber int) []TbaAward {
+	url := fmt.Sprint("/api/v2/team/", string(getTbaTeam(teamNumber)), "/history/awards")
+	resp, _ := getTbaRequest(url)
 
-  // Get the response and handle errors
+	// Get the response and handle errors
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil
 	}
-	
+
 	var awardData []TbaAward
-  json.Unmarshal(body, &awardData)
-  
-  return awardData
+	json.Unmarshal(body, &awardData)
+
+	return awardData
 }
 
 // PUBLISHING
@@ -293,12 +291,12 @@ func postTbaRequest(resource string, body []byte) (*http.Response, error) {
 
 // Sends a GET request to the TBA API
 func getTbaRequest(path string) (*http.Response, error) {
-  // Make an HTTP GET request with the TBA auth headers
+	// Make an HTTP GET request with the TBA auth headers
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", fmt.Sprint(tbaBaseUrl, path), nil)
 	if err != nil {
-	  return nil, err
+		return nil, err
 	}
 	req.Header.Set("X-TBA-App-Id", "cheesy-arena:cheesy-fms:v0.1")
-  return client.Do(req)
+	return client.Do(req)
 }

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -91,10 +91,25 @@
               </div>
             </div>
           </div>
+        </fieldset>
+        <fieldset>
+          <legend>FRC Events API</legend>
           <div class="form-group">
-            <label class="col-lg-7 control-label">Enable Team Info Download From usfirst.org</label>
+            <label class="col-lg-7 control-label">Enable FRC Events API Team Info Download</label>
             <div class="col-lg-1 checkbox">
-              <input type="checkbox" name="teamInfoDownloadEnabled"{{if .TeamInfoDownloadEnabled}} checked{{end}}>
+              <input type="checkbox" name="FMSAPIDownloadEnabled"{{if .FMSAPIDownloadEnabled}} checked{{end}}>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-lg-5 control-label">FRC Events API Username</label>
+            <div class="col-lg-7">
+              <input type="text" class="form-control" name="FMSAPIUsername" value="{{.FMSAPIUsername}}">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-lg-5 control-label">FRC Events API Authorization Key</label>
+            <div class="col-lg-7">
+              <input type="text" class="form-control" name="FMSAPIAuthKey" value="{{.FMSAPIAuthKey}}">
             </div>
           </div>
         </fieldset>

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -93,23 +93,17 @@
           </div>
         </fieldset>
         <fieldset>
-          <legend>FRC Events API</legend>
+          <legend>Automatic Team Info Download</legend>
           <div class="form-group">
-            <label class="col-lg-7 control-label">Enable FRC Events API Team Info Download</label>
+            <label class="col-lg-9 control-label">Enable Automatic Team Info Download (From TBA)</label>
             <div class="col-lg-1 checkbox">
-              <input type="checkbox" name="FMSAPIDownloadEnabled"{{if .FMSAPIDownloadEnabled}} checked{{end}}>
+              <input type="checkbox" name="TBADownloadEnabled"{{if .TBADownloadEnabled}} checked{{end}}>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-lg-5 control-label">FRC Events API Username</label>
-            <div class="col-lg-7">
-              <input type="text" class="form-control" name="FMSAPIUsername" value="{{.FMSAPIUsername}}">
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="col-lg-5 control-label">FRC Events API Authorization Key</label>
-            <div class="col-lg-7">
-              <input type="text" class="form-control" name="FMSAPIAuthKey" value="{{.FMSAPIAuthKey}}">
+            <label class="col-lg-9 control-label">Enable Automatic Team Accomplishments Download (From TBA)</label>
+            <div class="col-lg-1 checkbox">
+              <input type="checkbox" name="TBADownloadEnabled"{{if .TBAAwardsDownloadEnabled}} checked{{end}}>
             </div>
           </div>
         </fieldset>

--- a/templates/setup_teams.html
+++ b/templates/setup_teams.html
@@ -18,7 +18,7 @@
     <form class="form-horizontal" action="/setup/teams" method="POST">
       <fieldset>
         <legend>Import Teams</legend>
-        {{if not .EventSettings.FMSAPIDownloadEnabled}}<p>To automatically download data about teams, enter your FRC Events API key on the event settings page</p>{{end}}
+        {{if not .EventSettings.TBADownloadEnabled}}<p>To automatically download data about teams, enable TBA Team Info Download on the settings page</p>{{end}}
         <div class="form-group">
           <textarea class="form-control" rows="10" name="teamNumbers"
               placeholder="One team number per line"></textarea>

--- a/templates/setup_teams.html
+++ b/templates/setup_teams.html
@@ -18,6 +18,7 @@
     <form class="form-horizontal" action="/setup/teams" method="POST">
       <fieldset>
         <legend>Import Teams</legend>
+        {{if not .EventSettings.FMSAPIDownloadEnabled}}<p>To automatically download data about teams, enter your FRC Events API key on the event settings page</p>{{end}}
         <div class="form-group">
           <textarea class="form-control" rows="10" name="teamNumbers"
               placeholder="One team number per line"></textarea>


### PR DESCRIPTION
I changed the code base to use the FRC Events API to pull down team info.  The existing method is non-functional right now due to FIRST having pulled down the page it scrapes causing an exception to be thrown until the feature is disabled.

Using the FRC Events API works well but has a few disadvantages:
* End-users must obtain and API Key
* It is difficult to get all the team information at once because the API will only return 20 teams at a time.  This requires that we make a request for each team.

I added 3 new fields to the event settings table:
* FMSAPIDownloadEnabled (whether to use the API or not)
* FMSAPIUsername (the username to use for authentication)
* FMSAPIAuthKey (the authentication key to use for authentication)

They were added in a new migration to preserve existing databases.
There is now a floating column teaminfodownloadenabled which should eventually be removed.