### PR TITLE
Add basic travis CI YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go


### PR DESCRIPTION
Default Travis CI behavior is to fetch all dependencies including test
dependencies, then build, and test, which should be sufficient.

These builds will fail till the unit tests are fixed (which I'll probably put in a different PR)