### PR TITLE
Use correct TBA key for backup robots

### DIFF
--- a/db/migrations/20161003014944_AddOrigTeamNumberToTeams.sql
+++ b/db/migrations/20161003014944_AddOrigTeamNumberToTeams.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE teams ADD COLUMN origteamnumber INTEGER DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE teams DROP COLUMN origteamnumber;

--- a/setup_teams.go
+++ b/setup_teams.go
@@ -139,6 +139,7 @@ func TeamEditPostHandler(w http.ResponseWriter, r *http.Request) {
 	team.StateProv = r.PostFormValue("stateProv")
 	team.Country = r.PostFormValue("country")
 	team.RookieYear, _ = strconv.Atoi(r.PostFormValue("rookieYear"))
+	team.OrigTeamNumber, _ = strconv.Atoi(r.PostFormValue("origTeamNumber"))
 	team.RobotName = r.PostFormValue("robotName")
 	team.Accomplishments = r.PostFormValue("accomplishments")
 	if eventSettings.NetworkSecurityEnabled {

--- a/tba.go
+++ b/tba.go
@@ -383,7 +383,12 @@ func DeletePublishedMatches() error {
 
 // Converts an integer team number into the "frcXXXX" format TBA expects.
 func getTbaTeam(team int) string {
-	return fmt.Sprintf("frc%d", team)
+	resolved_team, _ := db.GetTeamById(team)
+	if resolved_team.OrigTeamNumber != 0 {
+		return fmt.Sprintf("frc%dB", resolved_team.OrigTeamNumber)
+	} else {
+		return fmt.Sprintf("frc%d", team)
+	}
 }
 
 // HELPERS

--- a/team.go
+++ b/team.go
@@ -17,6 +17,7 @@ type Team struct {
 	Accomplishments string
 	WpaKey          string
 	YellowCard      bool
+	OrigTeamNumber	int
 }
 
 func (database *Database) CreateTeam(team *Team) error {

--- a/templates/edit_team.html
+++ b/templates/edit_team.html
@@ -49,6 +49,12 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="col-lg-3 control-label">Original Team Number (if backup)</label>
+            <div class="col-lg-9">
+              <input type="text" class="form-control" name="origTeamNumber" value="{{.Team.OrigTeamNumber}}">
+            </div>
+          </div>
+          <div class="form-group">
             <label class="col-lg-3 control-label">Robot Name</label>
             <div class="col-lg-9">
               <input type="text" class="form-control" name="robotName" value="{{.Team.RobotName}}">


### PR DESCRIPTION
TBA expects keys like "1234B" for backup robots, and has no way to
distinguish that "9234" is the backup bot for "1234" aside from being
manually told. Use the approriate team key when pushing to TBA.
