### PR TITLE
Allow force publishing of the schedule (fixes #24)

### DIFF
--- a/setup_schedule.go
+++ b/setup_schedule.go
@@ -94,6 +94,24 @@ func ScheduleGeneratePostHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/setup/schedule", 302)
 }
 
+// Publishes the schedule in the database to TBA
+func ScheduleRepublishPostHandler(w http.ResponseWriter, r *http.Request) {
+	if eventSettings.TbaPublishingEnabled {
+		// Publish schedule to The Blue Alliance.
+		err := DeletePublishedMatches()
+		if err != nil {
+			http.Error(w, "Failed to delete published matches: "+err.Error(), 500)
+			return
+		}
+		err = PublishMatches()
+		if err != nil {
+			http.Error(w, "Failed to publish matches: "+err.Error(), 500)
+			return
+		}
+	}
+
+	http.Redirect(w, r, "/setup/schedule", 302)
+}
 // Saves the generated schedule to the database.
 func ScheduleSavePostHandler(w http.ResponseWriter, r *http.Request) {
 	if !UserIsAdmin(w, r) {

--- a/setup_schedule.go
+++ b/setup_schedule.go
@@ -108,10 +108,14 @@ func ScheduleRepublishPostHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to publish matches: "+err.Error(), 500)
 			return
 		}
+	} else {
+		http.Error(w, "TBA publishing is not enabled", 500)
+		return
 	}
 
 	http.Redirect(w, r, "/setup/schedule", 302)
 }
+
 // Saves the generated schedule to the database.
 func ScheduleSavePostHandler(w http.ResponseWriter, r *http.Request) {
 	if !UserIsAdmin(w, r) {

--- a/templates/setup_schedule.html
+++ b/templates/setup_schedule.html
@@ -53,6 +53,15 @@
               <button type="submit" class="btn btn-primary">Save Schedule</button>
             </div>
           </div>
+          {{if .EventSettings.TbaPublishingEnabled}}
+          <div class="form-group">
+            <div class="col-lg-12">
+                  <button type="button" class="btn btn-info" onclick="$('#confirmPublishSchedule').modal('show');">
+                    Publish Schedule to TBA
+                  </button>
+            </div>
+          </div>
+          {{end}}
         </fieldset>
       </form>
     </div>
@@ -135,6 +144,27 @@
     </div>
   </div>
 </div>
+<div id="confirmPublishSchedule" class="modal" style="top: 20%;">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h4 class="modal-title">Confirm</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to publish the schedule to The Blue Alliance? This will overwrite any
+          existing matches and their data.</p>
+      </div>
+      <div class="modal-footer">
+        <form class="form-horizontal" action="/setup/schedule/republish" method="POST">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Publish Schedule</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
 {{end}}
 {{define "script"}}
 <script>var numTeams = {{.NumTeams}};</script>

--- a/web.go
+++ b/web.go
@@ -175,6 +175,7 @@ func newHandler() http.Handler {
 	router.HandleFunc("/setup/teams/generate_wpa_keys", TeamsGenerateWpaKeysHandler).Methods("GET")
 	router.HandleFunc("/setup/schedule", ScheduleGetHandler).Methods("GET")
 	router.HandleFunc("/setup/schedule/generate", ScheduleGeneratePostHandler).Methods("POST")
+	router.HandleFunc("/setup/schedule/republish", ScheduleRepublishPostHandler).Methods("POST")
 	router.HandleFunc("/setup/schedule/save", ScheduleSavePostHandler).Methods("POST")
 	router.HandleFunc("/setup/alliance_selection", AllianceSelectionGetHandler).Methods("GET")
 	router.HandleFunc("/setup/alliance_selection", AllianceSelectionPostHandler).Methods("POST")


### PR DESCRIPTION
Co-written by @ograff 

Adds a button to the match schedule generation to force a push to TBA - useful for when you want to generate and save a match schedule before publishing it to everyone. The frontend code was based off of the similar button to force publish the team list to TBA.