### PR TITLE
Remove number input spinners

### DIFF
--- a/static/css/cheesy-arena.css
+++ b/static/css/cheesy-arena.css
@@ -105,3 +105,7 @@
 .btn-lower-third {
   width: 80px;
 }
+input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}


### PR DESCRIPTION
This fixes [the issue noted on #19](https://github.com/Team254/cheesy-arena/pull/19#issuecomment-252406733). It will remove the annoying chromium `up` and `down` number input buttons, which are useless when team numbers are in the thousands.