### PR TITLE
Add team list for alliance selection

### DIFF
--- a/db/migrations/20140524160241_CreateEventSettings.sql
+++ b/db/migrations/20140524160241_CreateEventSettings.sql
@@ -6,6 +6,7 @@ CREATE TABLE event_settings (
   numelimalliances int,
   selectionround2order VARCHAR(1),
   selectionround3order VARCHAR(1),
+  selectionshowunpickedteams bool,
   teaminfodownloadenabled bool,
   tbapublishingenabled bool,
   tbaeventcode VARCHAR(16),

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -12,6 +12,7 @@ type EventSettings struct {
 	NumElimAlliances           int
 	SelectionRound2Order       string
 	SelectionRound3Order       string
+	SelectionShowUnpickedTeams bool
 	TBADownloadEnabled         bool
 	TbaPublishingEnabled       bool
 	TbaEventCode               string
@@ -43,6 +44,7 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		eventSettings.NumElimAlliances = 8
 		eventSettings.SelectionRound2Order = "L"
 		eventSettings.SelectionRound3Order = ""
+		eventSettings.SelectionShowUnpickedTeams = false
 		eventSettings.TBADownloadEnabled = true
 
 		err = database.eventSettingsMap.Insert(eventSettings)

--- a/static/css/audience_display.css
+++ b/static/css/audience_display.css
@@ -344,6 +344,28 @@ html {
   height: 100%;
   right: 3em;
 }
+
+#allianceRankingsCentering {
+  position: absolute;
+  height: 100%;
+  left: 3em;
+}
+
+#allianceRankings {
+  background-color: #fff;
+  padding: .5em 1em;
+  border: 2px solid #222;
+  font-size: 2em;
+  color: #222;
+  font-family: "FuturaLT";
+  -webkit-column-count: 4;
+  -moz-column-count: 4;
+  column-count: 4;
+  -webkit-column-gap: 1em;
+  -moz-column-gap: 1em;
+  column-gap: 1em;
+}
+
 #allianceSelection {
   display: table-cell;
   vertical-align: middle;

--- a/static/js/audience_display.js
+++ b/static/js/audience_display.js
@@ -105,12 +105,21 @@ var handlePlaySound = function(sound) {
 
 // Handles a websocket message to update the alliance selection screen.
 var handleAllianceSelection = function(alliances) {
-  if (alliances) {
-    var numColumns = alliances[0].length + 1;
-    $.each(alliances, function(k, v) {
+  if (alliances.Alliances) {
+    var numColumns = alliances.Alliances[0].length + 1;
+    $.each(alliances.Alliances, function(k, v) {
       v.Index = k + 1;
     });
-    $("#allianceSelection").html(allianceSelectionTemplate({alliances: alliances, numColumns: numColumns}));
+    $("#allianceSelection").html(allianceSelectionTemplate({alliances: alliances.Alliances, numColumns: numColumns}));
+    if (alliances.Rankings) {
+      var text = '';
+      $.each(alliances.Rankings, function(i, v) {
+        if (!v.Picked) {
+          text += v.Rank + '. ' + v.TeamId + '<br />';
+        }
+      });
+      $("#allianceRankings").html(text);
+    }
   }
 };
 
@@ -255,10 +264,13 @@ var transitionScoreToBlank = function(callback) {
 var transitionBlankToAllianceSelection = function(callback) {
   $('#allianceSelectionCentering').css("right","-60em").show();
   $('#allianceSelectionCentering').transition({queue: false, right: "3em"}, 500, "ease", callback);
+  $('#allianceRankingsCentering.enabled').css('left', '-60em').show();
+  $('#allianceRankingsCentering.enabled').transition({queue: false, left: "3em"}, 500, "ease");
 };
 
 var transitionAllianceSelectionToBlank = function(callback) {
   $('#allianceSelectionCentering').transition({queue: false, right: "-60em"}, 500, "ease", callback);
+  $('#allianceRankingsCentering.enabled').transition({queue:false, left: "-60em"}, 500, "ease");
 };
 
 var transitionBlankToLowerThird = function(callback) {

--- a/templates/audience_display.html
+++ b/templates/audience_display.html
@@ -135,6 +135,9 @@
     <div id="allianceSelectionCentering" style="display: none;">
       <div id="allianceSelection"></div>
     </div>
+    <div id="allianceRankingsCentering" {{if .SelectionShowUnpickedTeams}}class="enabled"{{end}} style="display: none;">
+      <div id="allianceRankings"></div>
+    </div>
     <div id="lowerThird">
       <img id="lowerThirdLogo" src="/static/img/lower-third-logo.png" alt="logo" />
       <div id="lowerThirdTop"></div>

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -85,6 +85,12 @@
               </div>
             </div>
           </div>
+          <div class="form-group">
+            <label class="col-lg-9 control-label">Show unpicked teams during alliance selection</label>
+            <div class="col-lg-1 checkbox">
+              <input type="checkbox" name="selectionShowUnpickedTeams"{{if .SelectionShowUnpickedTeams}} checked{{end}}>
+            </div>
+          </div>
         </fieldset>
         <fieldset>
           <legend>Automatic Team Info Download</legend>

--- a/web/audience_display.go
+++ b/web/audience_display.go
@@ -117,7 +117,11 @@ func (web *Web) audienceDisplayWebsocketHandler(w http.ResponseWriter, r *http.R
 		log.Printf("Websocket error: %s", err)
 		return
 	}
-	err = websocket.Write("allianceSelection", cachedAlliances)
+	data = struct {
+		Alliances [][]*model.AllianceTeam
+		Rankings  []*RankedTeam
+	}{cachedAlliances, cachedRankedTeams}
+	err = websocket.Write("allianceSelection", data)
 	if err != nil {
 		log.Printf("Websocket error: %s", err)
 		return
@@ -185,7 +189,10 @@ func (web *Web) audienceDisplayWebsocketHandler(w http.ResponseWriter, r *http.R
 					return
 				}
 				messageType = "allianceSelection"
-				message = cachedAlliances
+				message = struct {
+					Alliances [][]*model.AllianceTeam
+					Rankings  []*RankedTeam
+				}{cachedAlliances, cachedRankedTeams}
 			case lowerThird, ok := <-lowerThirdListener:
 				if !ok {
 					return

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -50,6 +50,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.NumElimAlliances = numAlliances
 	eventSettings.SelectionRound2Order = r.PostFormValue("selectionRound2Order")
 	eventSettings.SelectionRound3Order = r.PostFormValue("selectionRound3Order")
+	eventSettings.SelectionShowUnpickedTeams = r.PostFormValue( "selectionShowUnpickedTeams") == "on"
 	eventSettings.TBADownloadEnabled = r.PostFormValue("TBADownloadEnabled") == "on"
 	eventSettings.TbaPublishingEnabled = r.PostFormValue("tbaPublishingEnabled") == "on"
 	eventSettings.TbaEventCode = r.PostFormValue("tbaEventCode")


### PR DESCRIPTION
So teams and announcers can still see who is available. We used this at CalGames 2016.
