### PR TITLE
Fixed title formatting in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Cheesy Arena
 ============
 A field management system that just works.
 
-##Key features
+## Key features
 Check out a [video overview](http://video.team254.com/watch/Z5ZWI2cDqsvVe--AjHhePAHlOhLK8MT0) of Cheesy Arena's functionality.
 
 **For participants and spectators:**
@@ -22,10 +22,10 @@ Check out a [video overview](http://video.team254.com/watch/Z5ZWI2cDqsvVe--AjHhe
 * Streamlined realtime score entry
 * Reports, results, and logs can be viewed from any computer
 
-##License
+## License
 Teams may use Cheesy Arena freely for practice, scrimmages, and off-season events. See [LICENSE](LICENSE) for more details.
 
-##Installation and use
+## Installation and use
 **Via binaries:**
 
 1. Download the [latest release](https://github.com/Team254/cheesy-arena/releases) for OS X or Windows
@@ -47,7 +47,7 @@ Teams may use Cheesy Arena freely for practice, scrimmages, and off-season event
 
 Set the IP address of the computer running Cheesy Arena to 10.0.100.5. Driver stations will broadcast their presence on the network to this hardcoded address so that the FMS does not need to discover them by some other method.
 
-##Under the hood
+## Under the hood
 Cheesy Arena is written using [Go](http://golang.org), a relatively new language developed by Google. Go excels in the areas of concurrency, networking, performance, and portability, which makes it ideal for a field management system.
 
 Cheesy Arena is implemented as a web server, with all human interaction done via browser. The graphical interfaces are implemented in HTML, JavaScript, and CSS. There are many advantages to this approach &ndash; development of new graphical elements is rapid, and no software needs to be installed other than on the server. Client web pages send commands and receive updates using WebSockets.
@@ -64,7 +64,7 @@ Due to the prohibitive cost of the LEDs and LED controllers used on official fie
 ## Advanced networking
 See the [Advanced Networking wiki page](https://github.com/Team254/cheesy-arena/wiki/Advanced-Networking) for instructions on what equipment to obtain and how to configure it in order to support advanced network security.
 
-##Contributing
+## Contributing
 Cheesy Arena is far from finished! You can help by:
 
 * Checking out the [TODO list](TODO.md), writing a missing feature, and sending a pull request
@@ -72,7 +72,7 @@ Cheesy Arena is far from finished! You can help by:
 * Contributing documentation to the [wiki](https://github.com/Team254/cheesy-arena/wiki)
 * Sending baked goods to Pat
 
-##Acknowledgements
+## Acknowledgements
 [Several folks](https://github.com/Team254/cheesy-arena/graphs/contributors) have contributed pull requests. Thanks!
 
 In addition, the following individuals have contributed to make Cheesy Arena a reality:

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 Cheesy Arena To-Do List
 =======================
 
-###Features for FRC parity
+### Features for FRC parity
 * Event wizard to guide scorekeeper through running an event
 * Awards tracking and publishing
 * Elimination bracket report and audience screen
@@ -10,12 +10,12 @@ Cheesy Arena To-Do List
 * Quality of service
 * Twitter publishing
 
-###Public-facing features
+### Public-facing features
 * Fancier graphics and animations for alliance station display
 * Ability to yank the match data from the Internet for an existing event, for use just in webcast overlays
 * GameSense-style next match screen with robot photos
 
-###Scorekeeper-facing features
+### Scorekeeper-facing features
 * Ability to unscore a match and reset it to non-played status
 * Logging console on Match Play page for errors and warnings
 * Team/field timeout tracking and overlay
@@ -23,11 +23,11 @@ Cheesy Arena To-Do List
 * Automatic creation of lower thirds for awards
 * Persist schedule blocks after schedule generation, in case the schedule needs to be tweaked and re-run
 
-###Features for other volunteers
+### Features for other volunteers
 * Referee interface: add timer starting at field reset to track time limit for calling timeouts/backups
 * Mobile compatibility for announcer display
 
-###Cheesy Arena Lite - a game-agnostic version
+### Cheesy Arena Lite - a game-agnostic version
 * Configurable match period timing
 * Realtime scoring: just a simple single number input, plus API
 * Final score screen: just show point total and remove breakdowns
@@ -35,7 +35,7 @@ Cheesy Arena To-Do List
 * Manual input of match name
 * Remove match scheduling and team standings functionality
 
-###Development tasks
+### Development tasks
 * Generate more schedules and find an automated way to evaluate them
 * Clean up sponsor carousel JavaScript and make it load new slides asynchronously without needing a reload of the audience display page
 * Refactor websockets to reduce code repetition between displays with similar functions


### PR DESCRIPTION
I literally did nothing except fix the title formatting in the readme/todo files because some update to Markdown broke it or something (TBA had the same issue).