### PR TITLE
Add a button for force push alliances to TBA after selection

### DIFF
--- a/templates/setup_alliance_selection.html
+++ b/templates/setup_alliance_selection.html
@@ -15,11 +15,21 @@
   {{end}}
   {{if len .Alliances | eq 0}}
     <div class="col-lg-3">
+      {{if .SelectionFinalized}}
+        <legend>Alliance Selection</legend>
+        Alliance selection has already been finalized.
+        {{if .EventSettings.TbaPublishingEnabled}}
+        <form action="/setup/alliance_selection/tba" method="POST">
+          <button type="submit" class="btn btn-info">Publish alliances to The Blue Alliance</button>
+        </form>
+        {{end}}
+      {{else}}
       <form action="/setup/alliance_selection/start" method="POST">
         <legend>Alliance Selection</legend>
         <button type="submit" class="btn btn-info">Start Alliance Selection</button>
       </form>
     </div>
+    {{end}}
   {{else}}
     <form action="/setup/alliance_selection" method="POST">
       <div class="col-lg-3 ">

--- a/web/web.go
+++ b/web/web.go
@@ -147,6 +147,7 @@ func (web *Web) newHandler() http.Handler {
 	router.HandleFunc("/setup/alliance_selection/start", web.allianceSelectionStartHandler).Methods("POST")
 	router.HandleFunc("/setup/alliance_selection/reset", web.allianceSelectionResetHandler).Methods("POST")
 	router.HandleFunc("/setup/alliance_selection/finalize", web.allianceSelectionFinalizeHandler).Methods("POST")
+	router.HandleFunc("/setup/alliance_selection/tba", web.allianceSelectionTbaHandler).Methods("POST")
 	router.HandleFunc("/setup/field", web.fieldGetHandler).Methods("GET")
 	router.HandleFunc("/setup/field", web.fieldPostHandler).Methods("POST")
 	router.HandleFunc("/setup/field/reload_displays", web.fieldReloadDisplaysHandler).Methods("GET")


### PR DESCRIPTION
If Cheesy Arena does not have Internet when alliances are finalized,
there's no way to republish the alliances. So add a button to do so if
selection has already completed.

Also don't show a misleading "Start Alliance Selection" button if it's
just going to error out that alliances have already been finalized.