### PR TITLE
Change bandwidth units to megabits + fix .csv match log formatting

### DIFF
--- a/field/bandwidth_monitor.go
+++ b/field/bandwidth_monitor.go
@@ -117,7 +117,7 @@ func (monitor *BandwidthMonitor) updateStationBandwidth(station string, oidIndex
 		return
 	}
 	lastToRobotBytesForPort := uint32(monitor.lastToRobotBytes[toOid].(wapsnmp.Counter))
-	dsConn.MBpsToRobot = float64(toRobotBytesForPort-lastToRobotBytesForPort) / 1024 / 1024 / secondsSinceLast
+	dsConn.MBpsToRobot = float64(toRobotBytesForPort-lastToRobotBytesForPort) / 1024 / 128 / secondsSinceLast
 
 	fromOid := monitor.fromRobotOids[oidIndex].String()
 	if _, ok := fromRobotBytes[fromOid]; !ok {
@@ -130,5 +130,5 @@ func (monitor *BandwidthMonitor) updateStationBandwidth(station string, oidIndex
 		return
 	}
 	lastFromRobotBytesForPort := uint32(monitor.lastFromRobotBytes[fromOid].(wapsnmp.Counter))
-	dsConn.MBpsFromRobot = float64(fromRobotBytesForPort-lastFromRobotBytesForPort) / 1024 / 1024 / secondsSinceLast
+	dsConn.MBpsFromRobot = float64(fromRobotBytesForPort-lastFromRobotBytesForPort) / 1024 / 128 / secondsSinceLast
 }

--- a/field/team_match_log.go
+++ b/field/team_match_log.go
@@ -36,7 +36,7 @@ func NewTeamMatchLog(teamId int, match *model.Match) (*TeamMatchLog, error) {
 	}
 
 	log := TeamMatchLog{log.New(logFile, "", 0), logFile}
-	log.logger.Println("matchTimeSec,packetType,teamId,allianceStation,robotLinked,auto,enabled," +
+	log.logger.Println("matchTimeSec,packetType,teamId,allianceStation,radioLinked,robotLinked,auto,enabled," +
 		"emergencyStop,batteryVoltage,missedPacketCount,dsRobotTripTimeMs")
 
 	return &log, nil
@@ -44,7 +44,7 @@ func NewTeamMatchLog(teamId int, match *model.Match) (*TeamMatchLog, error) {
 
 // Adds a line to the log when a packet is received.
 func (log *TeamMatchLog) LogDsPacket(matchTimeSec float64, packetType int, dsConn *DriverStationConnection) {
-	log.logger.Printf("%f,%d,%d,%s,%v,%v,%v,%v,%f,%d,%d", matchTimeSec, packetType, dsConn.TeamId,
+	log.logger.Printf("%f,%d,%d,%s,%v,%v,%v,%v,%v,%f,%d,%d", matchTimeSec, packetType, dsConn.TeamId,
 		dsConn.AllianceStation, dsConn.RadioLinked, dsConn.RobotLinked, dsConn.Auto, dsConn.Enabled, dsConn.Estop,
 		dsConn.BatteryVoltage, dsConn.MissedPacketCount, dsConn.DsRobotTripTimeMs)
 }

--- a/templates/fta_display.html
+++ b/templates/fta_display.html
@@ -12,7 +12,7 @@
       <div class="col-lg-6 well well-darkred">
         <div class="row form-group">
           <div class="col-xs-3">Red Teams</div>
-          <div class="col-xs-1" data-toggle="tooltip" title="Driver Station (Tx/Rx MB/s)">DS</div>
+          <div class="col-xs-1" data-toggle="tooltip" title="Driver Station (Tx/Rx Mbits/s)">DS</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Radio Status">Rad</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Robot Status/Time Since Last Link">Rio</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Battery">Bat</div>
@@ -27,7 +27,7 @@
       <div class="col-lg-6 well well-darkblue">
         <div class="row form-group hidden-xs">
           <div class="col-xs-3">Blue Teams</div>
-          <div class="col-xs-1" data-toggle="tooltip" title="Driver Station (Tx/Rx MB/s)">DS</div>
+          <div class="col-xs-1" data-toggle="tooltip" title="Driver Station (Tx/Rx Mbits/s)">DS</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Radio Status">Rad</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Robot Status/Time Since Last Link">Rio</div>
           <div class="col-xs-1" data-toggle="tooltip" title="Battery">Bat</div>

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -63,7 +63,7 @@
       <div class="col-lg-6 well well-darkblue">
         <div class="row form-group">
           <div class="col-lg-4">Blue Teams</div>
-          <div class="col-lg-2" data-toggle="tooltip" title="Driver Station (Tx/Rx MB/s)">DS</div>
+          <div class="col-lg-2" data-toggle="tooltip" title="Driver Station (Tx/Rx Mbits/s)">DS</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Robot">R</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Battery">B</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Bypass/Disable">Byp</div>
@@ -75,7 +75,7 @@
       <div class="col-lg-6 well well-darkred">
         <div class="row form-group">
           <div class="col-lg-4">Red Teams</div>
-          <div class="col-lg-2" data-toggle="tooltip" title="Driver Station (Tx/Rx MB/s)">DS</div>
+          <div class="col-lg-2" data-toggle="tooltip" title="Driver Station (Tx/Rx Mbits/s)">DS</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Robot">R</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Battery">B</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Bypass/Disable">Byp</div>


### PR DESCRIPTION
Two small changes in one PR. Didn't feel like two separates were necessary.

Change 1: swap units of bandwidth measurement to megabits per second from megabytes per second. Robots will never come anywhere close to transmitting data amounting to actual megabytes, so megabits allows for field staff to quantify data transmission and also is what's used by the official field.

Change 2: the columns on match logs were shifted because of the addition of logging the radio connection state independent of the Rio. Now the columns are formatted correctly for each data field.

Both these changes were tested this past weekend at Capital City Classic without issue.