### PR TITLE
Change event name in settings from a preset value to a placeholder

### DIFF
--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -21,7 +21,7 @@
           <div class="form-group">
             <label class="col-lg-5 control-label">Name</label>
             <div class="col-lg-7">
-              <input type="text" class="form-control" name="name" value="{{.Name}}">
+              <input type="text" class="form-control" name="name" placeholder="{{.Name}}">
             </div>
           </div>
           <div class="form-group">

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -33,7 +33,13 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	eventSettings := web.arena.EventSettings
+	
+	previousName = eventSettings.Name
 	eventSettings.Name = r.PostFormValue("name")
+	if len(eventSettings.Name) < 1 && perviousName == "Untitled Event"{
+		eventSettings.Name = "Untitled Event"
+	}
+	
 	numAlliances, _ := strconv.Atoi(r.PostFormValue("numElimAlliances"))
 	if numAlliances < 2 || numAlliances > 16 {
 		web.renderSettings(w, r, "Number of alliances must be between 2 and 16.")

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -34,10 +34,10 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 
 	eventSettings := web.arena.EventSettings
 	
-	previousName = eventSettings.Name
+	perviousEventName = eventSettings.Name
 	eventSettings.Name = r.PostFormValue("name")
-	if len(eventSettings.Name) < 1 && perviousName == "Untitled Event"{
-		eventSettings.Name = "Untitled Event"
+	if len(eventSettings.Name) < 1 && eventSettings.Name != perviousEventName{
+		eventSettings.Name = perviousEventName
 	}
 	
 	numAlliances, _ := strconv.Atoi(r.PostFormValue("numElimAlliances"))


### PR DESCRIPTION
It was a little annoying that the event name input box in the settings did not clear itself when it was clicked on.

This pull request fixes that and stops the user from accidentally clearing the event name while changing other settings