### PR TITLE
Add option to disable realtime network config

### DIFF
--- a/db/migrations/20191212195826_AddNetworkConfigRT.sql
+++ b/db/migrations/20191212195826_AddNetworkConfigRT.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE event_settings ADD networkconfigrt bool;
+UPDATE event_settings SET networkconfigrt = 1;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE event_settings DROP networkconfigrt;
+-- +goose StatementEnd

--- a/field/arena.go
+++ b/field/arena.go
@@ -226,6 +226,54 @@ func (arena *Arena) LoadNextMatch() error {
 	return arena.LoadMatch(nextMatch)
 }
 
+// Assigns teams to the given stations, also substituting it into the match record.
+func (arena *Arena) PrestartMatch(R1 int, R2 int, R3 int, B1 int, B2 int, B3 int) error {
+	if !arena.CurrentMatch.ShouldAllowSubstitution() {
+		return fmt.Errorf("Can't substitute teams for qualification matches.")
+	}
+
+	arena.CurrentMatch.Red1 = R1
+	arena.CurrentMatch.Red2 = R2
+	arena.CurrentMatch.Red3 = R3
+	arena.CurrentMatch.Blue1 = B1
+	arena.CurrentMatch.Blue2 = B2
+	arena.CurrentMatch.Blue3 = B3
+
+	err := arena.assignTeam(R1, "R1")
+	if err != nil {
+		return err
+	}
+	err = arena.assignTeam(R2, "R2")
+	if err != nil {
+		return err
+	}
+	err = arena.assignTeam(R3, "R3")
+	if err != nil {
+		return err
+	}
+	err = arena.assignTeam(B1, "B1")
+	if err != nil {
+		return err
+	}
+	err = arena.assignTeam(B2, "B2")
+	if err != nil {
+		return err
+	}
+	err = arena.assignTeam(B3, "B3")
+	if err != nil {
+		return err
+	}
+
+	arena.setupNetwork([6]*model.Team{arena.AllianceStations["R1"].Team, arena.AllianceStations["R2"].Team,
+		arena.AllianceStations["R3"].Team, arena.AllianceStations["B1"].Team, arena.AllianceStations["B2"].Team,
+		arena.AllianceStations["B3"].Team})
+
+	if arena.CurrentMatch.Type != "test" {
+		arena.Database.SaveMatch(arena.CurrentMatch)
+	}
+	return nil
+}
+
 // Assigns the given team to the given station, also substituting it into the match record.
 func (arena *Arena) SubstituteTeam(teamId int, station string) error {
 	if !arena.CurrentMatch.ShouldAllowSubstitution() {

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -52,6 +52,39 @@ func TestAssignTeam(t *testing.T) {
 	}
 }
 
+func TestPrestartMatch(t *testing.T) {
+	arena := setupTestArena(t)
+
+	team1 := model.Team{Id: 1}
+	err := arena.Database.CreateTeam(&team1)
+	assert.Nil(t, err)
+	team2 := model.Team{Id: 2}
+	err = arena.Database.CreateTeam(&team2)
+	assert.Nil(t, err)
+	team3 := model.Team{Id: 3}
+	err = arena.Database.CreateTeam(&team3)
+	assert.Nil(t, err)
+	team4 := model.Team{Id: 4}
+	err = arena.Database.CreateTeam(&team4)
+	assert.Nil(t, err)
+	team5 := model.Team{Id: 5}
+	err = arena.Database.CreateTeam(&team5)
+	assert.Nil(t, err)
+	team6 := model.Team{Id: 6}
+	err = arena.Database.CreateTeam(&team6)
+	assert.Nil(t, err)
+
+	err = arena.PrestartMatch(1, 2, 3, 4, 5, 6)
+	assert.Nil(t, err)
+
+	assert.Equal(t, team1, *arena.AllianceStations["R1"].Team)
+	assert.Equal(t, team2, *arena.AllianceStations["R2"].Team)
+	assert.Equal(t, team3, *arena.AllianceStations["R3"].Team)
+	assert.Equal(t, team4, *arena.AllianceStations["B1"].Team)
+	assert.Equal(t, team5, *arena.AllianceStations["B2"].Team)
+	assert.Equal(t, team6, *arena.AllianceStations["B3"].Team)
+}
+
 func TestArenaCheckCanStartMatch(t *testing.T) {
 	arena := setupTestArena(t)
 

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -17,6 +17,7 @@ type EventSettings struct {
 	TbaSecretId            string
 	TbaSecret              string
 	NetworkSecurityEnabled bool
+	NetworkConfigRT        bool
 	ApAddress              string
 	ApUsername             string
 	ApPassword             string
@@ -51,6 +52,7 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		eventSettings.ApAdminWpaKey = "1234Five"
 		eventSettings.Ap2TeamChannel = 0
 		eventSettings.HabDockingThreshold = 15
+		eventSettings.NetworkConfigRT = true
 
 		err = database.eventSettingsMap.Insert(eventSettings)
 		if err != nil {

--- a/static/css/cheesy-arena.css
+++ b/static/css/cheesy-arena.css
@@ -71,8 +71,8 @@
   background-color: #fc0;
 }
 .btn-match-play {
-  width: 150px;
-  font-size: 16px;
+  width: 125px;
+  font-size: 14px;
 }
 .label-scoring {
   background-color: #e66;

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -23,6 +23,29 @@ var toggleBypassPreMatchScore = function() {
   websocket.send("toggleBypassPreMatchScore");
 };
 
+// Parse team number.  If NaN, use defaultNumber
+var parseTeamNum = function(position, defaultNumber) {
+  var num = parseInt($(`input[data='${position}']`).val());
+  if (isNaN(num)) {
+    num = defaultNumber;
+    $(`input[data='${position}']`).val(num);
+  }
+
+  return num;
+};
+
+// Sends a websocket message to prestart field network
+var preStart = function() {
+  websocket.send("prestartMatch", {
+     R1: parseTeamNum('R1', 1),
+     R2: parseTeamNum('R2', 2),
+     R3: parseTeamNum('R3', 3),
+     B1: parseTeamNum('B1', 4),
+     B2: parseTeamNum('B2', 5),
+     B3: parseTeamNum('B3', 6)
+  });
+};
+
 // Sends a websocket message to start the match.
 var startMatch = function() {
   websocket.send("startMatch",
@@ -145,6 +168,7 @@ var handleArenaStatus = function(data) {
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
       $("#startTimeout").prop("disabled", false);
+      $("#preStart").prop("disabled", false);
       break;
     case "START_MATCH":
     case "WARMUP_PERIOD":
@@ -157,6 +181,7 @@ var handleArenaStatus = function(data) {
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
       $("#startTimeout").prop("disabled", true);
+      $("#preStart").prop("disabled", true);
       break;
     case "POST_MATCH":
       $("#startMatch").prop("disabled", true);
@@ -165,6 +190,7 @@ var handleArenaStatus = function(data) {
       $("#discardResults").prop("disabled", false);
       $("#editResults").prop("disabled", false);
       $("#startTimeout").prop("disabled", true);
+      $("#preStart").prop("disabled", false);
       break;
     case "TIMEOUT_ACTIVE":
       $("#startMatch").prop("disabled", true);
@@ -173,6 +199,7 @@ var handleArenaStatus = function(data) {
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
       $("#startTimeout").prop("disabled", true);
+      $("#preStart").prop("disabled", false);
       break;
     case "POST_TIMEOUT":
       $("#startMatch").prop("disabled", true);
@@ -181,6 +208,7 @@ var handleArenaStatus = function(data) {
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
       $("#startTimeout").prop("disabled", true);
+      $("#preStart").prop("disabled", false);
       break;
   }
 

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -23,12 +23,13 @@ var toggleBypassPreMatchScore = function() {
   websocket.send("toggleBypassPreMatchScore");
 };
 
-// Parse team number.  If NaN, use defaultNumber
-var parseTeamNum = function(position, defaultNumber) {
-  var num = parseInt($(`input[data='${position}']`).val());
+// Parse team number.  If NaN, use 0
+var parseTeamNum = function(position) {
+  var input = $("input[data='" + position + "']");
+  var num = parseInt(input.val());
   if (isNaN(num)) {
-    num = defaultNumber;
-    $(`input[data='${position}']`).val(num);
+    num = 0;
+    input.val("");
   }
 
   return num;
@@ -37,12 +38,12 @@ var parseTeamNum = function(position, defaultNumber) {
 // Sends a websocket message to prestart field network
 var preStart = function() {
   websocket.send("prestartMatch", {
-     R1: parseTeamNum('R1', 1),
-     R2: parseTeamNum('R2', 2),
-     R3: parseTeamNum('R3', 3),
-     B1: parseTeamNum('B1', 4),
-     B2: parseTeamNum('B2', 5),
-     B3: parseTeamNum('B3', 6)
+     R1: parseTeamNum('R1'),
+     R2: parseTeamNum('R2'),
+     R3: parseTeamNum('R3'),
+     B1: parseTeamNum('B1'),
+     B2: parseTeamNum('B2'),
+     B3: parseTeamNum('B3')
   });
 };
 

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -86,6 +86,10 @@
       </div>
     </div>
     <div class="row text-center">
+      <button type="button" id="preStart" class="btn btn-default btn-lg btn-match-play {{if .EventSettings.NetworkConfigRT}}hidden{{end}}"
+          onclick="preStart();">
+          Pre-Start
+      </button>
       <button type="button" id="startMatch" class="btn btn-success btn-lg btn-match-play"
           onclick="startMatch();" disabled>
         Start Match
@@ -270,8 +274,8 @@
   <div class="col-lg-1">{{.position}} </div>
   <div class="col-lg-3">
     <input type="number" class="form-control input-sm" value="{{if ne 0 .team}}{{.team}}{{end}}"
-        onblur="substituteTeam($(this).val(), '{{.color}}{{.position}}');"
-        {{if not .data.AllowSubstitution}}disabled{{end}}>
+        {{if .data.NetworkConfigRT}}onblur="substituteTeam($(this).val(), '{{.color}}{{.position}}');"{{end}}
+        {{if not .data.AllowSubstitution}}disabled{{end}} data="{{.color}}{{.position}}">
   </div>
   <div class="col-lg-2 col-no-padding"><div class="ds-status"></div></div>
   <div class="col-lg-2 col-no-padding"><div class="radio-status"></div></div>

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -134,6 +134,12 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="col-lg-7 control-label">Enable real-time network configuration</label>
+            <div class="col-lg-1 checkbox">
+              <input type="checkbox" name="networkConfigRT"{{if .NetworkConfigRT}} checked{{end}}>
+            </div>
+          </div>
+          <div class="form-group">
             <label class="col-lg-5 control-label">AP Address</label>
             <div class="col-lg-7">
               <input type="text" class="form-control" name="apAddress" value="{{.ApAddress}}">

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -196,6 +196,25 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 				ws.WriteError(err.Error())
 				continue
 			}
+		case "prestartMatch":
+			args := struct {
+				R1 int
+				R2 int
+				R3 int
+				B1 int
+				B2 int
+				B3 int
+			}{}
+			err = mapstructure.Decode(data, &args)
+			if err != nil {
+				ws.WriteError(err.Error())
+				continue
+			}
+			err = web.arena.PrestartMatch(args.R1, args.R2, args.R3, args.B1, args.B2, args.B3)
+			if err != nil {
+				ws.WriteError(err.Error())
+				continue
+			}
 		case "toggleBypass":
 			station, ok := data.(string)
 			if !ok {

--- a/web/match_play_test.go
+++ b/web/match_play_test.go
@@ -285,6 +285,16 @@ func TestMatchPlayWebsocketCommands(t *testing.T) {
 	readWebsocketType(t, ws, "arenaStatus")
 	assert.Equal(t, false, web.arena.AllianceStations["R3"].Bypass)
 
+	// Test prestartMatch
+	ws.Write("prestartMatch", map[string]interface{}{"R1": 1, "R2": 2, "R3": 3, "B1": 4, "B2": 5, "B3": 6})
+	readWebsocketType(t, ws, "arenaStatus")
+	assert.Equal(t, 1, web.arena.CurrentMatch.Red1)
+	assert.Equal(t, 2, web.arena.CurrentMatch.Red2)
+	assert.Equal(t, 3, web.arena.CurrentMatch.Red3)
+	assert.Equal(t, 4, web.arena.CurrentMatch.Blue1)
+	assert.Equal(t, 5, web.arena.CurrentMatch.Blue2)
+	assert.Equal(t, 6, web.arena.CurrentMatch.Blue3)
+
 	// Go through match flow.
 	ws.Write("abortMatch", nil)
 	assert.Contains(t, readWebsocketError(t, ws), "Cannot abort match")

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -56,6 +56,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.TbaSecretId = r.PostFormValue("tbaSecretId")
 	eventSettings.TbaSecret = r.PostFormValue("tbaSecret")
 	eventSettings.NetworkSecurityEnabled = r.PostFormValue("networkSecurityEnabled") == "on"
+	eventSettings.NetworkConfigRT = r.PostFormValue("networkConfigRT") == "on"
 	eventSettings.ApAddress = r.PostFormValue("apAddress")
 	eventSettings.ApUsername = r.PostFormValue("apUsername")
 	eventSettings.ApPassword = r.PostFormValue("apPassword")


### PR DESCRIPTION
This adds a bool to Event Settings that disables real-time network configuration (setting teams on match play as scorekeeper inputs them).  If disabled, a Pre-Start button is added to match play.