### PR TITLE
Force displays to reload when settings change

### DIFF
--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -92,6 +92,9 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Force reload on all displays
+	web.arena.ReloadDisplaysNotifier.Notify()
+	
 	if eventSettings.AdminPassword != previousAdminPassword {
 		// Delete any existing user sessions to force a logout.
 		if err := web.arena.Database.TruncateUserSessions(); err != nil {


### PR DESCRIPTION
The timer displays and audience display can get out of sync when match times are changed mid-event.  This update forces all displays to reload.