### PR TITLE
Added more Trunk ports to accommodate for future field network gear

### DIFF
--- a/switch_config.txt
+++ b/switch_config.txt
@@ -1,7 +1,11 @@
 ! Baseline configuration for the Catalyst 3500-series switch. Load this into the switch prior to configuring
 ! Cheesy Arena to connect to it. Default password is 1234Five.
 !
-version 12.2
+!
+! Last configuration change at 13:18:54 UTC Sat Sep 28 2019
+! NVRAM config last updated at 13:18:57 UTC Sat Sep 28 2019
+!
+version 15.0
 no service pad
 service timestamps debug datetime msec
 service timestamps log datetime msec
@@ -12,20 +16,28 @@ hostname ChezySwitch
 boot-start-marker
 boot-end-marker
 !
+!
 enable secret 5 $1$kKSW$fCMwnMdYvXui1TulfyYHN/
-!
-!
 !
 no aaa new-model
 system mtu routing 1500
 ip routing
-ip dhcp excluded-address 10.0.100.1 10.0.100.150
+!
+ip dhcp excluded-address 10.0.100.1 10.0.100.100
 !
 ip dhcp pool dhcppool
-   network 10.0.100.0 255.255.255.0
-   domain-name team254.com
-   dns-server 8.8.8.8 8.8.4.4 
-   lease 7
+ network 10.0.100.0 255.255.255.0
+ domain-name team254.com
+ dns-server 8.8.8.8 8.8.4.4 
+ default-router 10.0.100.1 
+ lease 7
+!
+!
+!
+!
+!
+!
+!
 !
 !
 !
@@ -42,7 +54,6 @@ vlan internal allocation policy ascending
 !
 !
 !
-!
 interface GigabitEthernet0/1
  switchport trunk encapsulation dot1q
  switchport trunk native vlan 100
@@ -54,6 +65,7 @@ interface GigabitEthernet0/2
  switchport mode trunk
 !
 interface GigabitEthernet0/3
+ switchport access vlan 100
  switchport trunk encapsulation dot1q
  switchport trunk native vlan 100
  switchport mode trunk
@@ -72,40 +84,45 @@ interface GigabitEthernet0/6
  switchport mode access
 !
 interface GigabitEthernet0/7
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/8
  switchport access vlan 20
  switchport mode access
 !
 interface GigabitEthernet0/9
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/10
  switchport access vlan 30
  switchport mode access
 !
 interface GigabitEthernet0/11
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/12
  switchport access vlan 40
  switchport mode access
 !
 interface GigabitEthernet0/13
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/14
  switchport access vlan 50
  switchport mode access
 !
 interface GigabitEthernet0/15
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/16
  switchport access vlan 60
@@ -232,28 +249,34 @@ interface GigabitEthernet0/46
  switchport mode access
 !
 interface GigabitEthernet0/47
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/48
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/49
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/50
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/51
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface GigabitEthernet0/52
- switchport access vlan 100
- switchport mode access
+ switchport trunk encapsulation dot1q
+ switchport trunk native vlan 100
+ switchport mode trunk
 !
 interface Vlan1
  ip address 10.0.0.61 255.255.255.0
@@ -286,8 +309,9 @@ interface Vlan100
  ip address 10.0.100.2 255.255.255.0
 !
 ip classless
-no ip http server
-no ip http secure-server
+ip http server
+ip http secure-server
+!
 !
 !
 access-list 110 permit ip 10.0.1.0 0.0.0.255 host 10.0.100.5
@@ -305,6 +329,7 @@ access-list 160 permit udp any eq bootpc any eq bootps
 !
 snmp-server community 1234Five RO
 !
+vstack
 !
 line con 0
  exec-timeout 0 0


### PR DESCRIPTION
What: First block of ports on the switch are now reserved for special use and have been made trunks.
Port 47 and 48 as well as the SFP ports are also trunks.

Why: Spare trunk ports to accommodate for future field network gear