### PR TITLE
Enable Microcontroller Scoring

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,15 +4,16 @@
 package main
 
 import (
-	"github.com/Team254/cheesy-arena/field"
-	"github.com/Team254/cheesy-arena/web"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/Team254/cheesy-arena/field"
+	"github.com/Team254/cheesy-arena/web"
 )
 
 const eventDbPath = "./event.db"
-const httpPort = 8080
+const httpPort = 8081
 
 // Main entry point for the application.
 func main() {

--- a/templates/scoring_panel.html
+++ b/templates/scoring_panel.html
@@ -30,7 +30,6 @@
       </div>
     {{end}}
   </div>
-  {{if not .PlcIsEnabled}}
     <div id="elements">
       <div class="scoring-section">
         <div>
@@ -83,7 +82,6 @@
         </div>
       </div>
     </div>
-  {{end}}
 </div>
 <div id="instructions">Click or use the labeled keyboard shortcuts to toggle each element</div>
 <div id="commitMatchScore">


### PR DESCRIPTION
Disabled the plc enabled switch so that manual scoring can still be accessed in case someone wanted to use a PLC or Microcontroller for the estops and some automated scoring components. I also changed the default port for the web interface so it can interact with OpenPLC, which is a PLC programmer for RPi and Arduinos to enable cheap scoring options. (from 8080 to 8081 since 8080 is OpenPLC webpage and can't be changed easily)