### PR TITLE
Add mode for setting AP networks slowly

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -7,14 +7,15 @@ package field
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/Team254/cheesy-arena/bracket"
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/Team254/cheesy-arena/network"
 	"github.com/Team254/cheesy-arena/partner"
 	"github.com/Team254/cheesy-arena/plc"
-	"log"
-	"time"
 )
 
 const (
@@ -142,9 +143,9 @@ func (arena *Arena) LoadSettings() error {
 
 	// Initialize the components that depend on settings.
 	arena.accessPoint.SetSettings(settings.ApAddress, settings.ApUsername, settings.ApPassword,
-		settings.ApTeamChannel, settings.ApAdminChannel, settings.ApAdminWpaKey, settings.NetworkSecurityEnabled)
+		settings.ApTeamChannel, settings.ApAdminChannel, settings.ApAdminWpaKey, settings.NetworkSecurityEnabled, settings.UseMultiConnectionAPConfiguration)
 	arena.accessPoint2.SetSettings(settings.Ap2Address, settings.Ap2Username, settings.Ap2Password,
-		settings.Ap2TeamChannel, 0, "", settings.NetworkSecurityEnabled)
+		settings.Ap2TeamChannel, 0, "", settings.NetworkSecurityEnabled, settings.UseMultiConnectionAPConfiguration)
 	arena.networkSwitch = network.NewSwitch(settings.SwitchAddress, settings.SwitchPassword)
 	arena.Plc.SetAddress(settings.PlcAddress)
 	arena.TbaClient = partner.NewTbaClient(settings.TbaEventCode, settings.TbaSecretId, settings.TbaSecret)

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -20,6 +20,7 @@ type EventSettings struct {
 	TbaSecretId                                   string
 	TbaSecret                                     string
 	NetworkSecurityEnabled                        bool
+	UseMultiConnectionAPConfiguration             bool
 	ApAddress                                     string
 	ApUsername                                    string
 	ApPassword                                    string

--- a/network/access_point_test.go
+++ b/network/access_point_test.go
@@ -5,11 +5,12 @@ package network
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena/model"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"regexp"
 	"testing"
+
+	"github.com/Team254/cheesy-arena/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigureAccessPoint(t *testing.T) {
@@ -80,7 +81,7 @@ func TestConfigureAccessPoint(t *testing.T) {
 	// Should reject a missing WPA key.
 	_, err := generateAccessPointConfig([6]*model.Team{{Id: 254}, nil, nil, nil, nil, nil})
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "Invalid WPA key")
+		assert.Contains(t, err.Error(), "invalid WPA key")
 	}
 }
 

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -153,6 +153,15 @@
               <input type="checkbox" name="networkSecurityEnabled"{{if .NetworkSecurityEnabled}} checked{{end}}>
             </div>
           </div>
+          <p>This setting controls how configuration is sent to the AP. In general, it is more reliable to 
+               send the configuration one team at a time, and clearing the config between loading new teams.
+               However, this mode is still experimental and will slow down configuring the AP.</p>
+          <div class="form-group">
+            <label class="col-lg-7 control-label">Enable AP configuration multi-connection</label>
+            <div class="col-lg-1 checkbox">
+              <input type="checkbox" name="multiConnectionAPConfig"{{if .UseMultiConnectionAPConfiguration}} checked{{end}}>
+            </div>
+          </div>
           <div class="form-group">
             <label class="col-lg-5 control-label">AP Address</label>
             <div class="col-lg-7">

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -7,7 +7,6 @@ package web
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena/model"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Team254/cheesy-arena/model"
 )
 
 // Shows the event settings editing page.
@@ -62,6 +63,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.TbaSecretId = r.PostFormValue("tbaSecretId")
 	eventSettings.TbaSecret = r.PostFormValue("tbaSecret")
 	eventSettings.NetworkSecurityEnabled = r.PostFormValue("networkSecurityEnabled") == "on"
+	eventSettings.UseMultiConnectionAPConfiguration = r.PostFormValue("multiConnectionAPConfig") == "on"
 	eventSettings.ApAddress = r.PostFormValue("apAddress")
 	eventSettings.ApUsername = r.PostFormValue("apUsername")
 	eventSettings.ApPassword = r.PostFormValue("apPassword")


### PR DESCRIPTION
This commit adds a configuration setting that will commit team network configurations to the AP one at a time instead of all in one message. This is how FIRST FMS configures the AP, it seems to be more reliable due to a bug in OpenWRT when you commit the entire config at once.

I have left this as a setting since I'm not confident in this being reliable enough to be the default mode. It will be run in this mode at CalGames, and after some events have used it, I will be confident in setting this to be the default, and eventually making it the only mode.

The slow down is to ~15s to configure the AP, but I feel that this is worth it to not have errors updating the configuration that delay match play.

Let me know what you think