### PR TITLE
Disable PLC buzzer during auto and teleop

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -868,10 +868,12 @@ func (arena *Arena) handlePlcOutput() {
 			}()
 		}
 	case AutoPeriod:
+		arena.Plc.SetStackBuzzer(false)
 		fallthrough
 	case PausePeriod:
 		fallthrough
 	case TeleopPeriod:
+		arena.Plc.SetStackBuzzer(false)
 		arena.Plc.SetStackLights(false, false, false, true)
 	}
 }


### PR DESCRIPTION
Fixes edge case where the PLC triggers the buzzer during a match.