### PR TITLE
Add controls for Field Reset lights to match play

### DIFF
--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -152,7 +152,8 @@ var handleArenaStatus = function(data) {
       $("#startMatch").prop("disabled", !data.CanStartMatch);
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", true);
-      $("#signalReset").prop("disabled", true);
+      $("#signalReset").prop("disabled", false);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -167,6 +168,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", false);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", true);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -177,6 +179,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", false);
       $("#signalReset").prop("disabled", false);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", false);
       $("#discardResults").prop("disabled", false);
       $("#editResults").prop("disabled", false);
@@ -187,6 +190,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", false);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -196,7 +200,8 @@ var handleArenaStatus = function(data) {
       $("#startMatch").prop("disabled", true);
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", true);
-      $("#signalReset").prop("disabled", true);
+      $("#signalReset").prop("disabled", false);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -242,6 +242,12 @@
                        onclick="setAllianceStationDisplay();">Timeout
               </label>
             </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="allianceStationDisplay" value="fieldReset"
+                       onclick="setAllianceStationDisplay();"  id="fieldResetRadio">Field Reset
+              </label>
+            </div>
           </div>
           <p>Shown Match Result</p>
           <span class="label label-saved-match">

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -285,7 +285,7 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 			web.arena.FieldVolunteers = true
 			continue // Don't reload.
 		case "signalReset":
-			if web.arena.MatchState != field.PostMatch {
+			if web.arena.MatchState != field.PostMatch && web.arena.MatchState != field.PreMatch {
 				// Don't allow clearing the field until the match is over.
 				continue
 			}


### PR DESCRIPTION
Adds controls for Field Reset light and alliance display states.
![prematch](https://user-images.githubusercontent.com/10507571/194770327-6cf7487c-1fea-40b8-8232-3d2b0ce08d05.PNG)
![matchplay](https://user-images.githubusercontent.com/10507571/194770329-b0247d1f-0d35-49b9-bb0a-a94ccb6c7708.PNG)
![postmatch](https://user-images.githubusercontent.com/10507571/194770330-b8fe33bd-2f28-41a6-ae89-bd282d6a0833.PNG)
