### PR TITLE
Add Field Reset to Alliance Display switcher

### DIFF
--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -153,6 +153,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -167,6 +168,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", false);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", true);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -177,6 +179,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", false);
       $("#signalReset").prop("disabled", false);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", false);
       $("#discardResults").prop("disabled", false);
       $("#editResults").prop("disabled", false);
@@ -187,6 +190,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", false);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);
@@ -197,6 +201,7 @@ var handleArenaStatus = function(data) {
       $("#abortMatch").prop("disabled", true);
       $("#signalVolunteers").prop("disabled", true);
       $("#signalReset").prop("disabled", true);
+      $("#fieldResetRadio").prop("disabled", false);
       $("#commitResults").prop("disabled", true);
       $("#discardResults").prop("disabled", true);
       $("#editResults").prop("disabled", true);

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -242,6 +242,12 @@
                        onclick="setAllianceStationDisplay();">Timeout
               </label>
             </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="allianceStationDisplay" value="fieldReset"
+                       onclick="setAllianceStationDisplay();"  id="fieldResetRadio">Field Reset
+              </label>
+            </div>
           </div>
           <p>Shown Match Result</p>
           <span class="label label-saved-match">


### PR DESCRIPTION
Allows manually toggle Field Reset on the Alliance Station Displays.
This option is disabled during Auto and Teleop.
![image](https://user-images.githubusercontent.com/10507571/195416017-989db2e7-942b-4ba9-a9f3-5fb5d8759244.png)
![image](https://user-images.githubusercontent.com/10507571/195416057-1b17f0f0-e045-432d-91d6-7fa70ff19de3.png)
