### PR TITLE
Use event code in WPA filename

### DIFF
--- a/web/reports.go
+++ b/web/reports.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -574,6 +575,8 @@ func (web *Web) teamsPdfReportHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+var eventCodeRegexp = regexp.MustCompile("[0-9]*(.*)")
+
 // Generates a CSV-formatted report of the WPA keys, for import into the radio kiosk.
 func (web *Web) wpaKeysCsvReportHandler(w http.ResponseWriter, r *http.Request) {
 	if !web.userIsAdmin(w, r) {
@@ -586,8 +589,30 @@ func (web *Web) wpaKeysCsvReportHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	settings, err := web.arena.Database.GetEventSettings()
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+
+	var filename string
+	tbaCode := settings.TbaEventCode
+	name := settings.Name
+	if tbaCode != "" {
+		// If we use the event code, scrub the leading digits. This creates
+		// the filenames that the WPA kiosk will expect, e.g. 2022CACC becomes
+		// CACC.
+		filename = eventCodeRegexp.FindStringSubmatch(tbaCode)[1]
+	} else if name != "" {
+		filename = name
+	} else {
+		filename = "default"
+	}
+
+	filename = filename + ".wpa_keys.csv"
+
 	w.Header().Set("Content-Type", "text/csv")
-	w.Header().Set("Content-Disposition", "attachment; filename=wpa_keys.csv")
+	w.Header().Set("Content-Disposition", "attachment; filename="+filename)
 	for _, team := range teams {
 		_, err := w.Write([]byte(fmt.Sprintf("%d,%s\r\n", team.Id, team.WpaKey)))
 		if err != nil {

--- a/web/reports_test.go
+++ b/web/reports_test.go
@@ -126,7 +126,7 @@ func TestWpaKeysCsvReport(t *testing.T) {
 	recorder := web.getHttpResponse("/reports/csv/wpa_keys")
 	assert.Equal(t, 200, recorder.Code)
 	assert.Equal(t, "text/csv", recorder.Header()["Content-Type"][0])
-	assert.Equal(t, "attachment; filename=wpa_keys.csv", recorder.Header()["Content-Disposition"][0])
+	assert.Equal(t, "attachment; filename=Untitled Event.wpa_keys.csv", recorder.Header()["Content-Disposition"][0])
 	assert.Equal(t, "254,12345678\r\n1114,9876543210\r\n", recorder.Body.String())
 }
 


### PR DESCRIPTION
Add event code to WPA file name, this removes the step of renaming the csv file before importing into the Kiosk utility.

Note: events that have events codes that are more or less than 4 digits will need to still manually rename the file.

@baconstrip 