### PR TITLE
Driver Station Field Monitor

### DIFF
--- a/static/css/field_monitor_display.css
+++ b/static/css/field_monitor_display.css
@@ -11,6 +11,7 @@ body {
   height: 100%;
   font-family: FuturaLTBold;
   color: #fff;
+  background-color: #333;
 }
 .center {
   display: flex;
@@ -19,6 +20,12 @@ body {
 }
 .position-row {
   height: 29%;
+}
+.position-row[data-ds="true"] {
+  height: 31%;
+}
+.position-row[data-ds="true"][data-preMatch="false"] {
+  display: none;
 }
 #matchStatusRow {
   height: 6%;
@@ -29,6 +36,9 @@ body {
   font-size: 1.5vw;
   text-transform: uppercase;
 }
+#matchStatusRow[data-ds="true"][data-preMatch="false"]  {
+  display: none;
+}
 #eventStatusRow {
   height: 7%;
   display: flex;
@@ -37,6 +47,9 @@ body {
   background-color: #333;
   font-size: 1.5vw;
   text-transform: uppercase;
+}
+#eventStatusRow[data-ds="true"] {
+  display: none;
 }
 .left-position, .right-position {
   width: 8%;
@@ -49,6 +62,9 @@ body {
 .left-position[data-reversed=true], .right-position[data-reversed=false] {
   background-color: #2080ff;
 }
+.right-position[data-ds="true"] {
+  display: none;
+} 
 .team {
   width: 42%;
   height: 100%;
@@ -101,6 +117,9 @@ body {
 .team-box i {
   margin-right: 0.5vw;
 }
+.team-left[data-ds="true"] {
+  width: 100%;
+}
 .team-notes[data-fta="true"] {
   height: 40%;
   display: flex;
@@ -111,10 +130,16 @@ body {
 .team-notes[data-fta="false"] {
   display: none;
 }
+.team-notes[data-ds="true"] {
+  display: none;
+}
 .team-notes div {
   width: 96%;
   height: 96%;
   white-space: pre;
+}
+.team-right[data-ds="true"] {
+  display: none;
 }
 textarea {
   width: 96%;

--- a/static/js/field_monitor_display.js
+++ b/static/js/field_monitor_display.js
@@ -143,7 +143,12 @@ var handleMatchTime = function(data) {
   translateMatchTime(data, function(matchState, matchStateText, countdownSec) {
     $("#matchState").text(matchStateText);
     $("#matchTime").text(countdownSec);
-    });
+    if (matchStateText === "PRE-MATCH" | matchStateText === "POST-MATCH") {
+      $(".ds-dependent").attr("data-preMatch", "true");
+    } else {
+      $(".ds-dependent").attr("data-preMatch", "false");
+    }
+  });
 };
 
 // Handles a websocket message to update the match score.
@@ -200,9 +205,21 @@ $(function() {
     redSide = "left";
     blueSide = "right";
   }
+  
+  //Read if display to be used in a Driver Station, ignore FTA flag if so.
+  var driverStation = urlParams.get("ds");
+  if (driverStation === "true") {
+  $(".fta-dependent").attr("data-fta", "false");
+  $(".ds-dependent").attr("data-ds", driverStation);
+  } else {
+  $(".fta-dependent").attr("data-fta", urlParams.get("fta"));
+  $(".ds-dependent").attr("data-ds", driverStation);
+  }
+  
   $(".reversible-left").attr("data-reversed", reversed);
   $(".reversible-right").attr("data-reversed", reversed);
-  $(".fta-dependent").attr("data-fta", urlParams.get("fta"));
+
+
 
   // Set up the websocket back to the server.
   websocket = new CheesyWebsocket("/displays/field_monitor/websocket", {

--- a/templates/base.html
+++ b/templates/base.html
@@ -97,6 +97,8 @@
                   <li><a href="/displays/bracket">Bracket</a></li>
                   <li><a href="/displays/field_monitor">Field Monitor</a></li>
                   <li><a href="/displays/field_monitor?fta=true">Field Monitor (FTA)</a></li>
+                  <li><a href="/displays/field_monitor?ds=true&reversed=true">Field Monitor (Blue DS)</a></li>
+                  <li><a href="/displays/field_monitor?ds=true&reversed=false">Field Monitor (Red DS)</a></li>
                   <li><a href="/displays/queueing">Queueing</a></li>
                   <li><a href="/displays/rankings">Standings</a></li>
                   <li><a href="/displays/wall">Wall</a></li>

--- a/templates/field_monitor_display.html
+++ b/templates/field_monitor_display.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="/static/css/field_monitor_display.css" />
   </head>
   <body>
-  <div id="matchStatusRow">
+  <div id="matchStatusRow" class="ds-dependent">
   <div id="matchName" class="text-left" style="width: 45%; padding-left: 1%;"></div>
   <div id="matchTime" class="text-center" style="width: 10%;"></div>
   <div id="matchState" class="text-right" style="width: 45%; padding-right: 1%;"></div>
@@ -25,11 +25,11 @@
     {{template "row" dict "leftPosition" "1" "rightPosition" "3"}}
     {{template "row" dict "leftPosition" "2" "rightPosition" "2"}}
     {{template "row" dict "leftPosition" "3" "rightPosition" "1"}}
-  <div id="eventStatusRow">
-      <div id="leftScore" class="fta-dependent left-score text-center reversible-left" style="width: 8%; vertical-center;"></div>
-      <div id="cycleTimeMessage" class="text-center" style="width: 42%;"></div>
-      <div id="earlyLateMessage" class="text-center" style="width: 42%;"></div>
-      <div id="rightScore" class="right-score text-center fta-dependent reversible-right " style="width: 8%;"></div>
+  <div id="eventStatusRow" class="ds-dependent">
+      <div id="leftScore" class="fta-dependent ds-dependent left-score text-center reversible-left" style="width: 8% vertical-center;"></div>
+      <div id="cycleTimeMessage" class="text-center ds-dependent" style="width: 42%;"></div>
+      <div id="earlyLateMessage" class="text-center ds-dependent" style="width: 42%;"></div>
+      <div id="rightScore" class="right-score ds-dependent text-center fta-dependent reversible-right " style="width: 8%;"></div>
   </div>
   </body>
   <script src="/static/js/lib/jquery.min.js"></script>
@@ -43,16 +43,16 @@
 </html>
 
 {{define "row"}}
-  <div class="position-row center">
+  <div class="position-row center ds-dependent">
     <div class="left-position center reversible-left">{{.leftPosition}}</div>
     {{template "team" dict "side" "left" "position" .leftPosition}}
     {{template "team" dict "side" "right" "position" .rightPosition}}
-    <div class="right-position center reversible-right">{{.rightPosition}}</div>
+    <div class="right-position center ds-dependent reversible-right">{{.rightPosition}}</div>
   </div>
 {{end}}
 
 {{define "team"}}
-  <div id="{{.side}}Team{{.position}}" class="team">
+  <div id="{{.side}}Team{{.position}}" class="team team-{{.side}} ds-dependent">
     <div id="{{.side}}Team{{.position}}Id" class="team-id center fta-dependent"></div>
     <div id="{{.side}}Team{{.position}}Notes" class="team-notes fta-dependent" title="FTA Notes">
       <i class="glyphicon glyphicon-comment"></i>

--- a/web/field_monitor_display.go
+++ b/web/field_monitor_display.go
@@ -20,7 +20,7 @@ func (web *Web) fieldMonitorDisplayHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !web.enforceDisplayConfiguration(w, r, map[string]string{"reversed": "false", "fta": "false"}) {
+	if !web.enforceDisplayConfiguration(w, r, map[string]string{"ds": "false", "fta": "false", "reversed": "false"}) {
 		return
 	}
 

--- a/web/field_monitor_display_test.go
+++ b/web/field_monitor_display_test.go
@@ -15,7 +15,7 @@ import (
 func TestFieldMonitorDisplay(t *testing.T) {
 	web := setupTestWeb(t)
 
-	recorder := web.getHttpResponse("/displays/field_monitor?displayId=1&fta=true&reversed=false")
+	recorder := web.getHttpResponse("/displays/field_monitor?displayId=1&ds=false&fta=true&reversed=false")
 	assert.Equal(t, 200, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "Field Monitor - Untitled Event - Cheesy Arena")
 }
@@ -26,7 +26,7 @@ func TestFieldMonitorDisplayWebsocket(t *testing.T) {
 
 	server, wsUrl := web.startTestServer()
 	defer server.Close()
-	conn, _, err := gorillawebsocket.DefaultDialer.Dial(wsUrl+"/displays/field_monitor/websocket?displayId=1&fta=false",
+	conn, _, err := gorillawebsocket.DefaultDialer.Dial(wsUrl+"/displays/field_monitor/websocket?displayId=1&ds=false&fta=false",
 		nil)
 	assert.Nil(t, err)
 	defer conn.Close()
@@ -54,7 +54,7 @@ func TestFieldMonitorFtaDisplayWebsocket(t *testing.T) {
 
 	server, wsUrl := web.startTestServer()
 	defer server.Close()
-	conn, _, err := gorillawebsocket.DefaultDialer.Dial(wsUrl+"/displays/field_monitor/websocket?displayId=1&fta=true",
+	conn, _, err := gorillawebsocket.DefaultDialer.Dial(wsUrl+"/displays/field_monitor/websocket?displayId=1&ds=false&fta=true",
 		nil)
 	assert.Nil(t, err)
 	defer conn.Close()


### PR DESCRIPTION
Add configuration for field monitor to only show one alliance and blank out during matches. 
Allows for a wired field monitor in each driver station.