### PR TITLE
Add FRC Nexus Integration to get team lineups

### DIFF
--- a/static/js/nexus_integration.js
+++ b/static/js/nexus_integration.js
@@ -1,0 +1,38 @@
+const row = document.querySelector('#buttonBottomRow');
+
+const nexusButton = document.createElement('button');
+nexusButton.classList.add('btn', 'btn-dark', 'btn-lg', 'nexus');
+nexusButton.textContent = 'Nexus'
+row.prepend(nexusButton);
+
+nexusButton.addEventListener('click', loadLineups)
+
+async function loadLineups() {
+  let matchKey = document.querySelector('#matchName').textContent;
+  matchKey = matchKey.replace('Practice ', 'p');
+  matchKey = matchKey.replace('Match ', 'sf');
+  matchKey = matchKey.replace('Final ', 'f1m');
+
+  try {
+    let lineups = await(await fetch(`https://api.frc.nexus/v1/2023cc/${matchKey}/lineup`)).json();
+
+    let changed = false;
+    for(let i = 0; i < lineups.blue?.length; i++) {
+      let el = document.querySelector(`#statusB${i + 1} input.team-number`);
+      if(el.value === lineups.blue[i]) continue;
+      el.value = lineups.blue[i];
+      changed = true;
+    }
+    for(let i = 0; i < lineups.red?.length; i++) {
+      let el = document.querySelector(`#statusR${i + 1} input.team-number`);
+      if(el.value === lineups.red[i]) continue;
+      el.value = lineups.red[i];
+      changed = true;
+    }
+    if(changed) {
+      document.querySelector('#substituteTeams').disabled = false;
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+}

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -267,6 +267,7 @@
 {{define "script"}}
 <script src="/static/js/match_timing.js"></script>
 <script src="/static/js/match_play.js"></script>
+<script src="/static/js/nexus_integration.js"></script>
 {{end}}
 {{define "matchPlayTeam"}}
 <div class="row form-group" id="status{{.color}}{{.position}}">


### PR DESCRIPTION
frc.nexus Integration to pull team lineups for practice matches and playoffs.

Caveats that need to be addressed.
js file uses static value for event code, this should be automated before merging.

For playoffs the scorekeeper must be logged into Nexus with scorekeeper permissions, this is because the lineups are considered privileged and are not in the public API.