### PR TITLE
Added match log viewing

### DIFF
--- a/static/css/view_match_log.css
+++ b/static/css/view_match_log.css
@@ -1,0 +1,26 @@
+.table thead{
+    position: sticky;
+    top: 82px;
+    background-color: #fcfcfc;
+}
+
+.table {
+    text-align: center;
+}
+
+#matchTabs{
+    position: sticky;
+    top:40px;
+    background-color: #fcfcfc;
+    height:42px;
+}
+
+h1{
+    position: sticky;
+    top:0px;
+    height: 40px;
+    background-color: #fcfcfc;
+}
+[data-status-ok] {
+    color:black;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="/match_play">Match Play</a></li>
                   <li><a href="/match_review">Match Review</a></li>
-                  <li><a href="/static/logs">Match Logs</a></li>
+                  <li><a href="/match_logs">Match Logs</a></li>
                   <li><a href="/alliance_selection">Alliance Selection</a></li>
                 </ul>
               </li>

--- a/templates/match_logs.html
+++ b/templates/match_logs.html
@@ -1,0 +1,58 @@
+{{/*
+  Copyright 2014 Team 254. All Rights Reserved.
+  Author: pat@patfairbank.com (Patrick Fairbank)
+
+  UI for listing matches and their logs.
+*/}}
+{{define "title"}}Match Logs{{end}}
+{{define "body"}}
+<div class="row">
+  <ul class="nav nav-tabs" style="margin-bottom: 15px;">
+    <li{{if eq .CurrentMatchType practiceMatch }} class="active"{{end}}>
+      <a href="#Practice" data-toggle="tab">Practice</a>
+    </li>
+    <li{{if eq .CurrentMatchType qualificationMatch }} class="active"{{end}}>
+      <a href="#Qualification" data-toggle="tab">Qualification</a>
+    </li>
+    <li{{if eq .CurrentMatchType playoffMatch }} class="active"{{end}}>
+      <a href="#Playoff" data-toggle="tab">Playoff</a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    {{range $type, $matches := .MatchesByType}}
+      <div class="tab-pane {{if eq $.CurrentMatchType $type }} active{{end}}" id="{{$type}}">
+        <table class="table table-striped table-hover ">
+          <thead>
+            <tr>
+              <th>Match</th>
+              <th>Time</th>
+              <th class="text-center">Red Alliance</th>
+              <th class="text-center">Blue Alliance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range $match := $matches}}
+              <tr class="{{$match.ColorClass}}">
+                <td>{{$match.ShortName}}</td>
+                <td>{{$match.Time}}</td>
+                <td class="text-center red-text">
+                  <a href="/match_logs/{{$match.Id}}/R1/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.RedTeams 0}}</b></a>
+                  <a href="/match_logs/{{$match.Id}}/R2/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.RedTeams 1}}</b></a>
+                  <a href="/match_logs/{{$match.Id}}/R3/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.RedTeams 2}}</b></a>
+                </td>
+                <td class="text-center blue-text">
+                  <a href="/match_logs/{{$match.Id}}/B1/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.BlueTeams 0}}</b></a>
+                  <a href="/match_logs/{{$match.Id}}/B2/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.BlueTeams 1}}</b></a>
+                  <a href="/match_logs/{{$match.Id}}/B3/log" target="_blank"><b class="btn btn-info btn-xs">{{index $match.BlueTeams 2}}</b></a>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+{{define "script"}}
+{{end}}

--- a/templates/view_match_log.html
+++ b/templates/view_match_log.html
@@ -1,0 +1,83 @@
+{{/*
+  Copyright 2018 Team 254. All Rights Reserved.
+  Author: pat@patfairbank.com (Patrick Fairbank)
+
+  Display showing robot connection status.
+*/}}
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Match Log - {{.Match.ShortName}} - {{ .MatchLogs.TeamId}}({{.MatchLogs.AllianceStation}}) - Cheesy Arena</title>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="shortcut icon" href="/static/img/favicon.ico">
+    <link rel="stylesheet" href="/static/css/lib/bootstrap.min.css" />
+    <link rel="stylesheet" href="/static/css/cheesy-arena.css" />
+    <link rel="stylesheet" href="/static/css/view_match_log.css" />
+    {{template "script" .}}
+  </head>
+  <body>
+  <div class="container">
+  <h1>{{.Match.ShortName}} - {{ .MatchLogs.TeamId}}({{.MatchLogs.AllianceStation}}) Log </h1>
+  <ul id="matchTabs" class="nav nav-tabs" style="margin-bottom: 15px;">
+  {{range $logs := .MatchLogs.Logs}}
+    <li{{if eq $logs.StartTime $.FirstMatch }} class="active"{{end}}>
+      <a href="#{{$logs.StartTime}}" data-toggle="tab">{{$logs.StartTime}}</a>
+    </li>
+  {{end}}
+  </ul>
+  <div class="tab-content">
+    {{range $logs := .MatchLogs.Logs}}
+      <div class="tab-pane {{if eq $.FirstMatch $logs.StartTime}} active{{end}}" id="{{$logs.StartTime}}">
+        <table class="table">
+          <thead class="thead-dark">
+            <tr>
+              <th>Match Time</th>
+              <th>DS Linked</th>
+              <th>Radio Linked</th>
+              <th>Robot Linked</th>
+              <th>Mode</th>
+              <th>Enabled</th>
+              <th>E-Stop</th>
+              <th>Voltage</th>
+              <th>Missed Packets</th>
+              <th>Latency</th>
+              <th>TX Rate</th>
+              <th>RX Rate</th>
+              <th>SNR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range $row := $logs.Rows}}
+              <tr>
+                <td data-status-ok="{{and $row.DsLinked $row.RadioLinked $row.RobotLinked}}">{{printf "%.2f" $row.MatchTimeSec}}</td>
+                <td>{{$row.DsLinked}}</td>
+                <td>{{if $row.DsLinked}}{{$row.RadioLinked}}{{else}}*****{{end}}</td>
+                <td>{{if and $row.DsLinked $row.RadioLinked}}{{$row.RobotLinked}}{{else}}*****{{end}}</td>
+                <td>{{if $row.Auto}}Auto{{else}}Telop{{end}}</td>
+                <td>{{$row.Enabled}}</td>
+                <td>{{$row.EmergencyStop}}</td>
+                <td>{{printf "%.3f" $row.BatteryVoltage}}</td>
+                <td>{{$row.MissedPacketCount}}</td>
+                <td>{{$row.DsRobotTripTimeMs}}</td>
+                <td>{{$row.TxRate}}</td>
+                <td>{{$row.RxRate}}</td>
+                <td>{{$row.SignalNoiseRatio}}</td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      {{end}}
+    </div>
+</body>
+</html>
+{{define "script"}}
+
+<script src="/static/js/lib/jquery.min.js"></script>
+<script src="/static/js/lib/bootstrap.min.js"></script>
+<script src="/static/js/lib/moment.min.js"></script>
+<script src="/static/js/lib/bootstrap-datetimepicker.min.js"></script>
+<script src="/static/js/lib/handlebars-1.3.0.js"></script>
+{{end}}

--- a/web/match_logs.go
+++ b/web/match_logs.go
@@ -1,0 +1,265 @@
+// Copyright 2014 Team 254. All Rights Reserved.
+// Author: pat@patfairbank.com (Patrick Fairbank)
+//
+// Web routes for viewing match logs
+
+package web
+
+import (
+	"fmt"
+	"github.com/Team254/cheesy-arena/game"
+	"github.com/Team254/cheesy-arena/model"
+	"github.com/gorilla/mux"
+	"net/http"
+	"strconv"
+	"encoding/csv"
+	"os"
+	"path/filepath"
+)
+
+type MatchLogsListItem struct {
+	Id         int
+	ShortName  string
+	Time       string
+	RedTeams   []int
+	BlueTeams  []int
+	ColorClass string
+	IsComplete bool
+}
+
+type MatchLogRow struct {
+	MatchTimeSec float64
+	PacketType int
+	TeamId int
+	AllianceStation string
+	DsLinked bool
+	RadioLinked bool
+	RobotLinked bool
+	Auto bool
+	Enabled bool
+	EmergencyStop bool
+	BatteryVoltage float64
+	MissedPacketCount int
+	DsRobotTripTimeMs int
+	TxRate float64
+	RxRate float64
+	SignalNoiseRatio int
+}
+
+type MatchLog struct {
+	StartTime string
+	Rows []MatchLogRow
+}
+
+type MatchLogs struct {
+	TeamId int
+	AllianceStation string
+	Logs []MatchLog
+}
+// Shows the match Log interface.
+func (web *Web) matchLogsHandler(w http.ResponseWriter, r *http.Request) {
+	practiceMatches, err := web.buildMatchLogsList(model.Practice)
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+	qualificationMatches, err := web.buildMatchLogsList(model.Qualification)
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+	playoffMatches, err := web.buildMatchLogsList(model.Playoff)
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+
+	template, err := web.parseFiles("templates/match_logs.html", "templates/base.html")
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+	matchesByType := map[model.MatchType][]MatchLogsListItem{
+		model.Practice:      practiceMatches,
+		model.Qualification: qualificationMatches,
+		model.Playoff:       playoffMatches,
+	}
+	currentMatchType := web.arena.CurrentMatch.Type
+	if currentMatchType == model.Test {
+		currentMatchType = model.Practice
+	}
+	data := struct {
+		*model.EventSettings
+		MatchesByType    map[model.MatchType][]MatchLogsListItem
+		CurrentMatchType model.MatchType
+	}{web.arena.EventSettings, matchesByType, currentMatchType}
+	err = template.ExecuteTemplate(w, "base", data)
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+}
+
+// Shows the page to view a log for a match.
+func (web *Web) matchLogsViewGetHandler(w http.ResponseWriter, r *http.Request) {
+	match, matchLogs, _, err := web.getMatchLogFromRequest(r)
+	firstMatch := "0"
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+
+	template, err := web.parseFiles("templates/view_match_log.html")
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+	if len(matchLogs.Logs) > 0 {
+		firstMatch = matchLogs.Logs[0].StartTime
+	}
+	data := struct {
+		*model.EventSettings
+		Match           *model.Match
+		MatchLogs *MatchLogs
+		FirstMatch string
+	}{web.arena.EventSettings, match, matchLogs, firstMatch}
+	err = template.ExecuteTemplate(w, "view_match_log.html", data)
+	if err != nil {
+		handleWebErr(w, err)
+		return
+	}
+}
+
+// Load the match result for the match referenced in the HTTP query string.
+func (web *Web) getMatchLogFromRequest(r *http.Request) (*model.Match, *MatchLogs, bool, error) {
+	vars := mux.Vars(r)
+	matchId, _ := strconv.Atoi(vars["matchId"])
+	stationId := vars["stationId"]
+	match, err := web.arena.Database.GetMatchById(matchId)
+	
+	logs := MatchLogs{
+		TeamId: 0,
+		AllianceStation: stationId,
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if match == nil {
+		return nil, nil, false, fmt.Errorf("Error: No such match: %d", matchId)
+	}
+	switch stationId {
+	case "R1":
+		logs.TeamId = match.Red1
+	case "R2":
+		logs.TeamId = match.Red2
+	case "R3":
+		logs.TeamId = match.Red3
+	case "B1":
+		logs.TeamId = match.Blue1
+	case "B2":
+		logs.TeamId = match.Blue2
+	case "B3":
+		logs.TeamId = match.Blue3
+	}
+	headerMap := make(map[string]int)
+	//rows []MatchLogRow
+	// Load a csv file.
+	if logs.TeamId == 0 {
+		return nil, nil, false, nil
+	}
+	var files []string
+	files, _ = filepath.Glob(filepath.Join(".", "static", "logs", "*_*_Match_" + match.ShortName + "_" + strconv.Itoa(logs.TeamId) + ".csv"))
+	if len(files) == 0 {
+		return match, &logs, false, nil
+	}
+
+	for _, v :=range files{
+		f, _ := os.Open(v)
+		defer f.Close()
+		// Create a new reader.
+		reader := csv.NewReader(f)
+		
+		// Read row
+		header, _ := reader.Read()
+
+		// Add mapping: Column/property name --> record index
+		for i,v := range header {
+			headerMap[v] = i
+		}
+		records, _ := reader.ReadAll()
+		
+		var curlog = MatchLog{
+			StartTime: v[12:26],
+			Rows: make([]MatchLogRow, len(records)),
+		}
+		for i, record := range records {
+			var curRow MatchLogRow
+			curRow.MatchTimeSec, _ =   strconv.ParseFloat(record[headerMap["matchTimeSec"]], 64)
+			curRow.PacketType, _ =   strconv.Atoi(record[headerMap["packetType"]])
+			curRow.TeamId, _ =   strconv.Atoi(record[headerMap["teamId"]])
+			curRow.AllianceStation =   record[headerMap["allianceStation"]]
+			curRow.DsLinked, _ =   strconv.ParseBool(record[headerMap["dsLinked"]])
+			curRow.RadioLinked, _ =   strconv.ParseBool(record[headerMap["radioLinked"]])
+			curRow.RobotLinked, _ =   strconv.ParseBool(record[headerMap["robotLinked"]])
+			curRow.Auto, _ =   strconv.ParseBool(record[headerMap["auto"]])
+			curRow.Enabled, _ =    strconv.ParseBool(record[headerMap["enabled"]])
+			curRow.EmergencyStop, _ =   strconv.ParseBool(record[headerMap["emergencyStop"]])
+			curRow.BatteryVoltage, _ =   strconv.ParseFloat(record[headerMap["batteryVoltage"]], 64)
+			curRow.MissedPacketCount, _ =   strconv.Atoi(record[headerMap["missedPacketCount"]])
+			curRow.DsRobotTripTimeMs, _ =   strconv.Atoi(record[headerMap["dsRobotTripTimeMs"]])
+		if len(headerMap) >13 {
+
+			curRow.TxRate, _ =   strconv.ParseFloat(record[headerMap["txRate"]], 64)
+			curRow.RxRate, _ =   strconv.ParseFloat(record[headerMap["rxRate"]], 64)
+			curRow.SignalNoiseRatio, _ =   strconv.Atoi(record[headerMap["signalNoiseRatio"]])
+		} else {
+			curRow.TxRate =  -1
+			curRow.RxRate=   -1
+			curRow.SignalNoiseRatio =   -1
+		}
+
+		// Create new person and add to persons array
+		curlog.Rows[i] = curRow
+	}
+	
+	logs.Logs = append(logs.Logs, curlog)
+	
+	}
+	return match, &logs, false, nil
+}
+
+// Constructs the list of matches to display in the match Logs interface.
+func (web *Web) buildMatchLogsList(matchType model.MatchType) ([]MatchLogsListItem, error) {
+	matches, err := web.arena.Database.GetMatchesByType(matchType, false)
+	if err != nil {
+		return []MatchLogsListItem{}, err
+	}
+
+	matchLogsList := make([]MatchLogsListItem, len(matches))
+	for i, match := range matches {
+		matchLogsList[i].Id = match.Id
+		matchLogsList[i].ShortName = match.ShortName
+		matchLogsList[i].Time = match.Time.Local().Format("Mon 1/02 03:04 PM")
+		matchLogsList[i].RedTeams = []int{match.Red1, match.Red2, match.Red3}
+		matchLogsList[i].BlueTeams = []int{match.Blue1, match.Blue2, match.Blue3}
+		if err != nil {
+			return []MatchLogsListItem{}, err
+		}
+		switch match.Status {
+		case game.RedWonMatch:
+			matchLogsList[i].ColorClass = "danger"
+			matchLogsList[i].IsComplete = true
+		case game.BlueWonMatch:
+			matchLogsList[i].ColorClass = "info"
+			matchLogsList[i].IsComplete = true
+		case game.TieMatch:
+			matchLogsList[i].ColorClass = "warning"
+			matchLogsList[i].IsComplete = true
+		default:
+			matchLogsList[i].ColorClass = ""
+			matchLogsList[i].IsComplete = false
+		}
+	}
+
+	return matchLogsList, nil
+}

--- a/web/match_logs.go
+++ b/web/match_logs.go
@@ -6,15 +6,15 @@
 package web
 
 import (
+	"encoding/csv"
 	"fmt"
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/gorilla/mux"
 	"net/http"
-	"strconv"
-	"encoding/csv"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 type MatchLogsListItem struct {
@@ -28,34 +28,35 @@ type MatchLogsListItem struct {
 }
 
 type MatchLogRow struct {
-	MatchTimeSec float64
-	PacketType int
-	TeamId int
-	AllianceStation string
-	DsLinked bool
-	RadioLinked bool
-	RobotLinked bool
-	Auto bool
-	Enabled bool
-	EmergencyStop bool
-	BatteryVoltage float64
+	MatchTimeSec      float64
+	PacketType        int
+	TeamId            int
+	AllianceStation   string
+	DsLinked          bool
+	RadioLinked       bool
+	RobotLinked       bool
+	Auto              bool
+	Enabled           bool
+	EmergencyStop     bool
+	BatteryVoltage    float64
 	MissedPacketCount int
 	DsRobotTripTimeMs int
-	TxRate float64
-	RxRate float64
-	SignalNoiseRatio int
+	TxRate            float64
+	RxRate            float64
+	SignalNoiseRatio  int
 }
 
 type MatchLog struct {
 	StartTime string
-	Rows []MatchLogRow
+	Rows      []MatchLogRow
 }
 
 type MatchLogs struct {
-	TeamId int
+	TeamId          int
 	AllianceStation string
-	Logs []MatchLog
+	Logs            []MatchLog
 }
+
 // Shows the match Log interface.
 func (web *Web) matchLogsHandler(w http.ResponseWriter, r *http.Request) {
 	practiceMatches, err := web.buildMatchLogsList(model.Practice)
@@ -119,8 +120,8 @@ func (web *Web) matchLogsViewGetHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	data := struct {
 		*model.EventSettings
-		Match           *model.Match
-		MatchLogs *MatchLogs
+		Match      *model.Match
+		MatchLogs  *MatchLogs
 		FirstMatch string
 	}{web.arena.EventSettings, match, matchLogs, firstMatch}
 	err = template.ExecuteTemplate(w, "view_match_log.html", data)
@@ -136,9 +137,9 @@ func (web *Web) getMatchLogFromRequest(r *http.Request) (*model.Match, *MatchLog
 	matchId, _ := strconv.Atoi(vars["matchId"])
 	stationId := vars["stationId"]
 	match, err := web.arena.Database.GetMatchById(matchId)
-	
+
 	logs := MatchLogs{
-		TeamId: 0,
+		TeamId:          0,
 		AllianceStation: stationId,
 	}
 	if err != nil {
@@ -168,62 +169,62 @@ func (web *Web) getMatchLogFromRequest(r *http.Request) (*model.Match, *MatchLog
 		return nil, nil, false, nil
 	}
 	var files []string
-	files, _ = filepath.Glob(filepath.Join(".", "static", "logs", "*_*_Match_" + match.ShortName + "_" + strconv.Itoa(logs.TeamId) + ".csv"))
+	files, _ = filepath.Glob(filepath.Join(".", "static", "logs", "*_*_Match_"+match.ShortName+"_"+strconv.Itoa(logs.TeamId)+".csv"))
 	if len(files) == 0 {
 		return match, &logs, false, nil
 	}
 
-	for _, v :=range files{
+	for _, v := range files {
 		f, _ := os.Open(v)
 		defer f.Close()
 		// Create a new reader.
 		reader := csv.NewReader(f)
-		
+
 		// Read row
 		header, _ := reader.Read()
 
 		// Add mapping: Column/property name --> record index
-		for i,v := range header {
+		for i, v := range header {
 			headerMap[v] = i
 		}
 		records, _ := reader.ReadAll()
-		
+
 		var curlog = MatchLog{
 			StartTime: v[12:26],
-			Rows: make([]MatchLogRow, len(records)),
+			Rows:      make([]MatchLogRow, len(records)),
 		}
 		for i, record := range records {
 			var curRow MatchLogRow
-			curRow.MatchTimeSec, _ =   strconv.ParseFloat(record[headerMap["matchTimeSec"]], 64)
-			curRow.PacketType, _ =   strconv.Atoi(record[headerMap["packetType"]])
-			curRow.TeamId, _ =   strconv.Atoi(record[headerMap["teamId"]])
-			curRow.AllianceStation =   record[headerMap["allianceStation"]]
-			curRow.DsLinked, _ =   strconv.ParseBool(record[headerMap["dsLinked"]])
-			curRow.RadioLinked, _ =   strconv.ParseBool(record[headerMap["radioLinked"]])
-			curRow.RobotLinked, _ =   strconv.ParseBool(record[headerMap["robotLinked"]])
-			curRow.Auto, _ =   strconv.ParseBool(record[headerMap["auto"]])
-			curRow.Enabled, _ =    strconv.ParseBool(record[headerMap["enabled"]])
-			curRow.EmergencyStop, _ =   strconv.ParseBool(record[headerMap["emergencyStop"]])
-			curRow.BatteryVoltage, _ =   strconv.ParseFloat(record[headerMap["batteryVoltage"]], 64)
-			curRow.MissedPacketCount, _ =   strconv.Atoi(record[headerMap["missedPacketCount"]])
-			curRow.DsRobotTripTimeMs, _ =   strconv.Atoi(record[headerMap["dsRobotTripTimeMs"]])
-		if len(headerMap) >13 {
+			curRow.MatchTimeSec, _ = strconv.ParseFloat(record[headerMap["matchTimeSec"]], 64)
+			curRow.PacketType, _ = strconv.Atoi(record[headerMap["packetType"]])
+			curRow.TeamId, _ = strconv.Atoi(record[headerMap["teamId"]])
+			curRow.AllianceStation = record[headerMap["allianceStation"]]
+			curRow.DsLinked, _ = strconv.ParseBool(record[headerMap["dsLinked"]])
+			curRow.RadioLinked, _ = strconv.ParseBool(record[headerMap["radioLinked"]])
+			curRow.RobotLinked, _ = strconv.ParseBool(record[headerMap["robotLinked"]])
+			curRow.Auto, _ = strconv.ParseBool(record[headerMap["auto"]])
+			curRow.Enabled, _ = strconv.ParseBool(record[headerMap["enabled"]])
+			curRow.EmergencyStop, _ = strconv.ParseBool(record[headerMap["emergencyStop"]])
+			curRow.BatteryVoltage, _ = strconv.ParseFloat(record[headerMap["batteryVoltage"]], 64)
+			curRow.MissedPacketCount, _ = strconv.Atoi(record[headerMap["missedPacketCount"]])
+			curRow.DsRobotTripTimeMs, _ = strconv.Atoi(record[headerMap["dsRobotTripTimeMs"]])
+			if len(headerMap) > 13 {
 
-			curRow.TxRate, _ =   strconv.ParseFloat(record[headerMap["txRate"]], 64)
-			curRow.RxRate, _ =   strconv.ParseFloat(record[headerMap["rxRate"]], 64)
-			curRow.SignalNoiseRatio, _ =   strconv.Atoi(record[headerMap["signalNoiseRatio"]])
-		} else {
-			curRow.TxRate =  -1
-			curRow.RxRate=   -1
-			curRow.SignalNoiseRatio =   -1
+				curRow.TxRate, _ = strconv.ParseFloat(record[headerMap["txRate"]], 64)
+				curRow.RxRate, _ = strconv.ParseFloat(record[headerMap["rxRate"]], 64)
+				curRow.SignalNoiseRatio, _ = strconv.Atoi(record[headerMap["signalNoiseRatio"]])
+			} else {
+				curRow.TxRate = -1
+				curRow.RxRate = -1
+				curRow.SignalNoiseRatio = -1
+			}
+
+			// Create new person and add to persons array
+			curlog.Rows[i] = curRow
 		}
 
-		// Create new person and add to persons array
-		curlog.Rows[i] = curRow
-	}
-	
-	logs.Logs = append(logs.Logs, curlog)
-	
+		logs.Logs = append(logs.Logs, curlog)
+
 	}
 	return match, &logs, false, nil
 }

--- a/web/web.go
+++ b/web/web.go
@@ -126,7 +126,7 @@ func addNoCacheHeader(handler http.Handler) http.Handler {
 
 // Sets up the mapping between URLs and handlers.
 func (web *Web) newHandler() http.Handler {
-	
+
 	router := mux.NewRouter()
 	router.HandleFunc("/", web.indexHandler).Methods("GET")
 	router.HandleFunc("/alliance_selection", web.allianceSelectionGetHandler).Methods("GET")

--- a/web/web.go
+++ b/web/web.go
@@ -126,6 +126,7 @@ func addNoCacheHeader(handler http.Handler) http.Handler {
 
 // Sets up the mapping between URLs and handlers.
 func (web *Web) newHandler() http.Handler {
+	
 	router := mux.NewRouter()
 	router.HandleFunc("/", web.indexHandler).Methods("GET")
 	router.HandleFunc("/alliance_selection", web.allianceSelectionGetHandler).Methods("GET")
@@ -169,6 +170,8 @@ func (web *Web) newHandler() http.Handler {
 	router.HandleFunc("/match_play", web.matchPlayHandler).Methods("GET")
 	router.HandleFunc("/match_play/match_load", web.matchPlayMatchLoadHandler).Methods("GET")
 	router.HandleFunc("/match_play/websocket", web.matchPlayWebsocketHandler).Methods("GET")
+	router.HandleFunc("/match_logs", web.matchLogsHandler).Methods("GET")
+	router.HandleFunc("/match_logs/{matchId}/{stationId}/log", web.matchLogsViewGetHandler).Methods("GET")
 	router.HandleFunc("/match_review", web.matchReviewHandler).Methods("GET")
 	router.HandleFunc("/match_review/{matchId}/edit", web.matchReviewEditGetHandler).Methods("GET")
 	router.HandleFunc("/match_review/{matchId}/edit", web.matchReviewEditPostHandler).Methods("POST")


### PR DESCRIPTION
This change adds a basic viewer to the data that is logged into the match log files.  It is the start of work for issue https://github.com/Team254/cheesy-arena/issues/119 and more features are planned, but as this is my first contribution I wanted to make sure I put this forward for review if there are issues with my approach.

Things I have on my roadmap for the feature:
- Elevator buttons to move to next/previous connection/disconnection event in the log
- Tracking the time an indicator is in a bad state (similar to the count up timer in the match play screen)
- Adding match graphs for individual team logs
- Adding match graphs that will show multiple teams to look for field wide issues