### PR TITLE
Update DHCP Ranges

### DIFF
--- a/network/switch.go
+++ b/network/switch.go
@@ -79,7 +79,8 @@ func (sw *Switch) ConfigureTeamEthernet(teams [6]*model.Team) error {
 		}
 		teamPartialIp := fmt.Sprintf("%d.%d", team.Id/100, team.Id%100)
 		addTeamVlansCommand += fmt.Sprintf(
-			"ip dhcp excluded-address 10.%s.1 10.%s.100\n"+
+			"ip dhcp excluded-address 10.%s.1 10.%s.19\n"+
+			"ip dhcp excluded-address 10.%s.200 10.%s.254\n"+
 				"ip dhcp pool dhcp%d\n"+
 				"network 10.%s.0 255.255.255.0\n"+
 				"default-router 10.%s.%d\n"+

--- a/network/switch.go
+++ b/network/switch.go
@@ -90,6 +90,8 @@ func (sw *Switch) ConfigureTeamEthernet(teams [6]*model.Team) error {
 				"interface Vlan%d\nip address 10.%s.%d 255.255.255.0\n",
 			teamPartialIp,
 			teamPartialIp,
+			teamPartialIp,
+			teamPartialIp,
 			vlan,
 			teamPartialIp,
 			teamPartialIp,

--- a/network/switch.go
+++ b/network/switch.go
@@ -80,7 +80,7 @@ func (sw *Switch) ConfigureTeamEthernet(teams [6]*model.Team) error {
 		teamPartialIp := fmt.Sprintf("%d.%d", team.Id/100, team.Id%100)
 		addTeamVlansCommand += fmt.Sprintf(
 			"ip dhcp excluded-address 10.%s.1 10.%s.19\n"+
-			"ip dhcp excluded-address 10.%s.200 10.%s.254\n"+
+				"ip dhcp excluded-address 10.%s.200 10.%s.254\n"+
 				"ip dhcp pool dhcp%d\n"+
 				"network 10.%s.0 255.255.255.0\n"+
 				"default-router 10.%s.%d\n"+

--- a/network/switch_test.go
+++ b/network/switch_test.go
@@ -42,7 +42,7 @@ func TestConfigureSwitch(t *testing.T) {
 	assert.Equal(
 		t,
 		"password\nenable\npassword\nterminal length 0\nconfig terminal\n"+
-			"ip dhcp excluded-address 10.2.54.1 10.2.54.100\nip dhcp pool dhcp50\n"+
+			"ip dhcp excluded-address 10.2.54.1 10.2.54.19\nip dhcp excluded-address 10.2.54.200 10.2.54.254\nip dhcp pool dhcp50\n"+
 			"network 10.2.54.0 255.255.255.0\ndefault-router 10.2.54.4\nlease 7\n"+
 			"access-list 150 permit ip 10.2.54.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 150 permit udp any eq bootpc any eq bootps\n"+
@@ -62,32 +62,32 @@ func TestConfigureSwitch(t *testing.T) {
 	assert.Equal(
 		t,
 		"password\nenable\npassword\nterminal length 0\nconfig terminal\n"+
-			"ip dhcp excluded-address 10.11.14.1 10.11.14.100\nip dhcp pool dhcp10\n"+
+			"ip dhcp excluded-address 10.11.14.1 10.11.14.19\nip dhcp excluded-address 10.11.14.200 10.11.14.254\nip dhcp pool dhcp10\n"+
 			"network 10.11.14.0 255.255.255.0\ndefault-router 10.11.14.4\nlease 7\n"+
 			"access-list 110 permit ip 10.11.14.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 110 permit udp any eq bootpc any eq bootps\n"+
 			"interface Vlan10\nip address 10.11.14.4 255.255.255.0\n"+
-			"ip dhcp excluded-address 10.2.54.1 10.2.54.100\nip dhcp pool dhcp20\n"+
+			"ip dhcp excluded-address 10.2.54.1 10.2.54.19\nip dhcp excluded-address 10.2.54.200 10.2.54.254\nip dhcp pool dhcp20\n"+
 			"network 10.2.54.0 255.255.255.0\ndefault-router 10.2.54.4\nlease 7\n"+
 			"access-list 120 permit ip 10.2.54.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 120 permit udp any eq bootpc any eq bootps\n"+
 			"interface Vlan20\nip address 10.2.54.4 255.255.255.0\n"+
-			"ip dhcp excluded-address 10.2.96.1 10.2.96.100\nip dhcp pool dhcp30\n"+
+			"ip dhcp excluded-address 10.2.96.1 10.2.96.19\nip dhcp excluded-address 10.2.96.200 10.2.96.254\nip dhcp pool dhcp30\n"+
 			"network 10.2.96.0 255.255.255.0\ndefault-router 10.2.96.4\nlease 7\n"+
 			"access-list 130 permit ip 10.2.96.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 130 permit udp any eq bootpc any eq bootps\n"+
 			"interface Vlan30\nip address 10.2.96.4 255.255.255.0\n"+
-			"ip dhcp excluded-address 10.15.3.1 10.15.3.100\nip dhcp pool dhcp40\n"+
+			"ip dhcp excluded-address 10.15.3.1 10.15.3.19\nip dhcp excluded-address 10.15.3.200 10.15.3.254\nip dhcp pool dhcp40\n"+
 			"network 10.15.3.0 255.255.255.0\ndefault-router 10.15.3.4\nlease 7\n"+
 			"access-list 140 permit ip 10.15.3.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 140 permit udp any eq bootpc any eq bootps\n"+
 			"interface Vlan40\nip address 10.15.3.4 255.255.255.0\n"+
-			"ip dhcp excluded-address 10.16.78.1 10.16.78.100\nip dhcp pool dhcp50\n"+
+			"ip dhcp excluded-address 10.16.78.1 10.16.78.19\nip dhcp excluded-address 10.16.78.200 10.16.78.254\nip dhcp pool dhcp50\n"+
 			"network 10.16.78.0 255.255.255.0\ndefault-router 10.16.78.4\nlease 7\n"+
 			"access-list 150 permit ip 10.16.78.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 150 permit udp any eq bootpc any eq bootps\n"+
 			"interface Vlan50\nip address 10.16.78.4 255.255.255.0\n"+
-			"ip dhcp excluded-address 10.15.38.1 10.15.38.100\nip dhcp pool dhcp60\n"+
+			"ip dhcp excluded-address 10.15.38.1 10.15.38.19\nip dhcp excluded-address 10.15.38.200 10.15.38.254\nip dhcp pool dhcp60\n"+
 			"network 10.15.38.0 255.255.255.0\ndefault-router 10.15.38.4\nlease 7\n"+
 			"access-list 160 permit ip 10.15.38.0 0.0.0.255 host 10.0.100.5\n"+
 			"access-list 160 permit udp any eq bootpc any eq bootps\n"+

--- a/switch_config.txt
+++ b/switch_config.txt
@@ -23,7 +23,8 @@ no aaa new-model
 system mtu routing 1500
 ip routing
 !
-ip dhcp excluded-address 10.0.100.1 10.0.100.100
+ip dhcp excluded-address 10.0.100.1 10.0.100.125
+ip dhcp excluded-address 10.0.100.200 10.0.100.225
 !
 ip dhcp pool dhcppool
  network 10.0.100.0 255.255.255.0


### PR DESCRIPTION
Updated DHCP ranges to match FIRST FMS config
https://docs.wpilib.org/en/stable/docs/networking/networking-introduction/networking-basics.html#ethernet-wireless

Team DHCP range is now 10.TE.AM.20 - 10.TE.AM.199
VLAN100 DHCP range is now 10.0.100.126 - 10.0.100.199, 10.0.100.226 - 10.0.100.254
