### PR TITLE
Adds the option to show unpicked teams during alliance selection

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -47,6 +47,12 @@ const (
 	PostTimeout
 )
 
+type RankedTeam struct {
+	Rank   int
+	TeamId int
+	Picked bool
+}
+
 type Arena struct {
 	Database         *model.Database
 	EventSettings    *model.EventSettings
@@ -77,6 +83,7 @@ type Arena struct {
 	SavedRankings                     game.Rankings
 	AllianceStationDisplayMode        string
 	AllianceSelectionAlliances        []model.Alliance
+	AllianceSelectionRankedTeams      []*RankedTeam
 	AllianceSelectionShowTimer        bool
 	AllianceSelectionTimeRemainingSec int
 	PlayoffTournament                 *playoff.PlayoffTournament

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -69,10 +69,12 @@ func (arena *Arena) generateAllianceSelectionMessage() any {
 		Alliances        []model.Alliance
 		ShowTimer        bool
 		TimeRemainingSec int
+		RankedTeams      []*RankedTeam
 	}{
 		arena.AllianceSelectionAlliances,
 		arena.AllianceSelectionShowTimer,
 		arena.AllianceSelectionTimeRemainingSec,
+		arena.AllianceSelectionRankedTeams,
 	}
 }
 

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -21,6 +21,7 @@ type EventSettings struct {
 	NumPlayoffAlliances             int
 	SelectionRound2Order            string
 	SelectionRound3Order            string
+	SelectionShowUnpickedTeams      bool
 	TbaDownloadEnabled              bool
 	TbaPublishingEnabled            bool
 	TbaEventCode                    string
@@ -70,6 +71,7 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		NumPlayoffAlliances:             8,
 		SelectionRound2Order:            "L",
 		SelectionRound3Order:            "",
+		SelectionShowUnpickedTeams:      false,
 		TbaDownloadEnabled:              true,
 		ApChannel:                       36,
 		WarmupDurationSec:               game.MatchTiming.WarmupDurationSec,

--- a/static/css/audience_display.css
+++ b/static/css/audience_display.css
@@ -553,6 +553,26 @@ html {
   max-width: 800px;
   max-height: 400px;
 }
+#allianceRankingsCentering {
+  position: absolute;
+  height: 100%;
+  left: 3em;
+  top: 3em;
+}
+#allianceRankings {
+  background-color: #fff;
+  padding: .5em 1em;
+  border: 2px solid #222;
+  font-size: 2em;
+  color: #222;
+  font-family: "FuturaLT";
+  -webkit-column-count: 3;
+  -moz-column-count: 3;
+  column-count: 3;
+  -webkit-column-gap: 1em;
+  -moz-column-gap: 1em;
+  column-gap: 1em;
+}
 #allianceSelectionCentering {
   position: absolute;
   height: 100%;

--- a/static/js/audience_display.js
+++ b/static/js/audience_display.js
@@ -328,12 +328,22 @@ const handlePlaySound = function(sound) {
 // Handles a websocket message to update the alliance selection screen.
 const handleAllianceSelection = function(data) {
   const alliances = data.Alliances;
+  const rankedTeams = data.RankedTeams;
   if (alliances && alliances.length > 0) {
     const numColumns = alliances[0].TeamIds.length + 1;
     $.each(alliances, function(k, v) {
       v.Index = k + 1;
     });
     $("#allianceSelection").html(allianceSelectionTemplate({alliances: alliances, numColumns: numColumns}));
+  }
+  if (rankedTeams) {
+      var text = '';
+      $.each(rankedTeams, function(i, v) {
+        if (!v.Picked) {
+          text += v.Rank + '. ' + v.TeamId + '<br />';
+        }
+      });
+      $("#allianceRankings").html(text);
   }
 
   if (data.ShowTimer) {
@@ -373,11 +383,14 @@ const handleLowerThird = function(data) {
 
 const transitionAllianceSelectionToBlank = function(callback) {
   $('#allianceSelectionCentering').transition({queue: false, right: "-60em"}, 500, "ease", callback);
+  $('#allianceRankingsCentering.enabled').transition({queue:false, left: "-60em"}, 500, "ease");
 };
 
 const transitionBlankToAllianceSelection = function(callback) {
   $('#allianceSelectionCentering').css("right","-60em").show();
   $('#allianceSelectionCentering').transition({queue: false, right: "3em"}, 500, "ease", callback);
+  $('#allianceRankingsCentering.enabled').css('left', '-60em').show();
+  $('#allianceRankingsCentering.enabled').transition({queue: false, left: "3em"}, 500, "ease");
 };
 
 const transitionBlankToBracket = function(callback) {

--- a/templates/audience_display.html
+++ b/templates/audience_display.html
@@ -242,6 +242,9 @@
     <div id="allianceSelectionCentering" style="display: none;">
       <div id="allianceSelection"></div>
     </div>
+    <div id="allianceRankingsCentering" {{if .SelectionShowUnpickedTeams}}class="enabled"{{end}} style="display: none;">
+      <div id="allianceRankings"></div>
+    </div>
     <div id="lowerThird">
       <img id="lowerThirdLogo" src="/static/img/lower-third-logo.png" alt="logo" />
       <div id="lowerThirdTop"></div>

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -97,6 +97,13 @@
               </div>
             </div>
           </div>
+          <div class="row mb-3">
+            <label class="col-lg-8 control-label" for="selectionShowUnpickedTeams">Show Unpicked Teams</label>
+            <div class="col-lg-1 checkbox">
+              <input type="checkbox" id="selectionShowUnpickedTeams"
+                     name="selectionShowUnpickedTeams"{{if .SelectionShowUnpickedTeams}} checked{{end}}>
+            </div>
+          </div>
         </fieldset>
         <fieldset class="mb-4">
           <legend>Automatic Team Info Download</legend>

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -7,6 +7,7 @@ package web
 
 import (
 	"fmt"
+	"github.com/Team254/cheesy-arena/field"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -71,6 +72,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.NumPlayoffAlliances = numAlliances
 	eventSettings.SelectionRound2Order = r.PostFormValue("selectionRound2Order")
 	eventSettings.SelectionRound3Order = r.PostFormValue("selectionRound3Order")
+	eventSettings.SelectionShowUnpickedTeams = r.PostFormValue("selectionShowUnpickedTeams") == "on"
 	eventSettings.TbaDownloadEnabled = r.PostFormValue("tbaDownloadEnabled") == "on"
 	eventSettings.TbaPublishingEnabled = r.PostFormValue("tbaPublishingEnabled") == "on"
 	eventSettings.TbaEventCode = r.PostFormValue("tbaEventCode")
@@ -256,7 +258,7 @@ func (web *Web) clearDbHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		web.arena.AllianceSelectionAlliances = []model.Alliance{}
-		cachedRankedTeams = []*RankedTeam{}
+		web.arena.AllianceSelectionRankedTeams = []*field.RankedTeam{}
 	}
 
 	http.Redirect(w, r, "/setup/settings", 303)


### PR DESCRIPTION
This is another attempt at what @legoktm worked on several years back.

I'm using 3 columns instead of 4 so I'm hoping that gets rid of the overlap issues.

If not let me know what resolution I need to test on and I'll fix it.