### PR TITLE
Make the test harnesses compatible with windows

### DIFF
--- a/field/test_helpers.go
+++ b/field/test_helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/stretchr/testify/assert"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -19,10 +18,13 @@ import (
 func SetupTestArena(t *testing.T, uniqueName string) *Arena {
 	rand.Seed(0)
 	model.BaseDir = ".."
-	dbPath := filepath.Join(model.BaseDir, fmt.Sprintf("%s_test.db", uniqueName))
-	os.Remove(dbPath)
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, fmt.Sprintf("%s_test.db", uniqueName))
 	arena, err := NewArena(dbPath)
 	assert.Nil(t, err)
+	t.Cleanup(func() {
+		arena.Database.Close()
+	})
 	return arena
 }
 

--- a/model/test_helpers.go
+++ b/model/test_helpers.go
@@ -9,17 +9,19 @@ import (
 	"fmt"
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"path/filepath"
 	"testing"
 )
 
 func SetupTestDb(t *testing.T, uniqueName string) *Database {
 	BaseDir = ".."
-	dbPath := filepath.Join(BaseDir, fmt.Sprintf("%s_test.db", uniqueName))
-	os.Remove(dbPath)
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, fmt.Sprintf("%s_test.db", uniqueName))
 	database, err := OpenDatabase(dbPath)
 	assert.Nil(t, err)
+	t.Cleanup(func() {
+		database.Close()
+	})
 	return database
 }
 


### PR DESCRIPTION
The test helpers are currently using a unix-only pattern for creating temporary databases which fail when running tests on windows. Windows doesn't allow unlinking an open file, so in the current code the os.Remove silently fails on windows and leaves a database file around causing all tests that create a new database to see an existing non-writable db file and fail.

This PR switches to using Go's native solution for temporary files in tests, which cleanly removes the directory at the end of the test on all platforms.

There's a deeper change that could be done here of also removing the uniqueName argument from all of the tests since it's not needed any more, let me know if you'd like me to also do that.

These changes get the pass rate on windows up to ~97%. There's some other failures with line ending mismatches in report generation tests and some problems in the PLC tests with time.Now() having a much lower resolution (tens of ms on windows versus nanosecond-scale on unix), but at least there's enough passes that you can do local dev on windows and waive expected failures.