### PR TITLE
Update switch config to allow for internet uplink

### DIFF
--- a/switch_config.txt
+++ b/switch_config.txt
@@ -30,10 +30,11 @@ ip dhcp pool dhcppool
  network 10.0.100.0 255.255.255.0
  domain-name team254.com
  dns-server 8.8.8.8 8.8.4.4
- default-router 10.0.100.1
+ default-router 10.0.100.3
  lease 7
 !
 !
+ip route 0.0.0.0 0.0.0.0 10.0.100.1
 !
 !
 !


### PR DESCRIPTION
This change to the config is working for my Catalyst 3560G series switch to allow for internet uplink from VLAN 100 only.
This does require an external router on the same VLAN to be plugged into one of the VLAN 100 ports (such as 7 indicated here https://github.com/Team254/cheesy-arena/wiki/Field-Network-Setup).

Changing the default gateway to `10.0.100.3` fixed an issue I had with my mac not being able to cross VLANs to talk to the driver stations, and then adding the ip route from `0.0.0.0` to `10.0.100.1` tells the router in the switch that if it can't resolve the IP to something local that it should forward the traffic off to that IP which should be statically set on the external router

This fix should allow you to remove the comment here: https://github.com/Team254/cheesy-arena/wiki/Configuring-New-Networking-Equipment#switch-setup since the internet uplink works now