### PR TITLE
Color fix

### DIFF
--- a/static/css/referee_panel.css
+++ b/static/css/referee_panel.css
@@ -166,6 +166,10 @@ h3 {
   border: 0;
   border-radius: 0.2vw;
 }
+.rule-select option {
+  background-color: #222;
+  color: #fff;
+}
 .delete-button {
   width: 6vw;
   height: 3vw;


### PR DESCRIPTION
Fixes issue https://github.com/Team254/cheesy-arena/issues/153, which seemed to be on Windows Chromium based browsers.

To my eye, it looks roughly the same as before on Firefox (and I would assume Safari), but this make the look consistent on Windows-Chromium browsers, fixing the issue in 153.

Before (Chromium based, Windows):
![Screenshot 2025-05-05 220846](https://github.com/user-attachments/assets/7782517d-1081-4e81-bb74-1f5a58b70372)

Before (Firefox, Windows):
![Screenshot 2025-05-05 220910](https://github.com/user-attachments/assets/8bc68f32-f2b3-4783-8241-2108fe9b3911)

After (Chromium based, Windows):
![Screenshot 2025-05-05 220940](https://github.com/user-attachments/assets/c36647d2-c129-4edb-87cf-15bebeed5e8c)

After (Firefox, Windows):
![Screenshot 2025-05-05 220951](https://github.com/user-attachments/assets/0cc8e3ff-48ee-4c29-a30d-10ad78deface)
