### PR TITLE
Make L1 coral count clearer when editing auto

### DIFF
--- a/static/css/scoring_panel.css
+++ b/static/css/scoring_panel.css
@@ -352,11 +352,13 @@ main {
 #reef-controls-warning {
   position: absolute;
   height: 100%;
-  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
 }
 
-[data-editing-auto="true"] #reef-controls-warning {
-  visibility: visible;
+[data-scoring-auto="true"][data-in-teleop="true"] #reef-controls-warning {
+  opacity: 1;
+  transition: opacity 0.2s ease-in-out;
 }
 
 .reef-column {
@@ -424,7 +426,7 @@ main {
   visibility: hidden;
 }
 
-[data-editing-auto="true"] #edit-auto {
+[data-scoring-auto="true"] #edit-auto {
   background-color: var(--green-action);
   color: var(--text-active);
 }
@@ -489,7 +491,22 @@ main {
 }
 
 .counter-value {
+  font-weight: bold;
+}
+
+.counter-main-value {
   font-size: 28pt;
+  transition: font-size 0.2s ease-in-out;
+}
+
+.counter-main-clone {
+  font-size: 0;
+  transition: font-size 0.2s ease-in-out;
+}
+
+.counter-auto-value {
+  font-size: 12pt;
+  transition: font-size 0.2s ease-in-out;
   font-weight: bold;
 }
 
@@ -501,16 +518,25 @@ main {
   justify-content: center;
   align-items: center;
   gap: 0.1em;
+  font-size: 12pt;
+  transition: font-size 0.2s ease-in-out;
+}
+
+[data-scoring-auto="true"] .counter-auto-row,
+[data-scoring-auto="true"] .counter-status:has(.counter-auto-row) .counter-main-value {
+  font-size: 0pt;
+}
+[data-scoring-auto="true"] .counter-auto-value {
+  font-size: 28pt;
+}
+[data-scoring-auto="true"] .counter-main-clone {
+  font-size: 12pt;
 }
 
 .counter:has(button:enabled) .counter-auto-row {
   background-color: var(--auto-action);
   color: var(--text-active-dark);
   box-shadow: black 0px 0px 2px;
-}
-
-.counter-auto-value {
-  font-weight: bold;
 }
 
 #endgame-dialog {

--- a/static/js/scoring_panel.js
+++ b/static/js/scoring_panel.js
@@ -99,7 +99,8 @@ const updateUIMode = function() {
   $(".scoring-teleop-button").prop('disabled', !(inTeleop && scoringAvailable));
   $("#commit").prop('disabled', !commitAvailable);
   $("#edit-auto").prop('disabled', !(inTeleop && scoringAvailable));
-  $(".container").attr("data-editing-auto", editingAuto);
+  $(".container").attr("data-scoring-auto", (!inTeleop || editingAuto) && scoringAvailable);
+  $(".container").attr("data-in-teleop", inTeleop && scoringAvailable);
   $("#edit-auto").text(editingAuto ? "Save Auto" : "Edit Auto");
 }
 

--- a/templates/scoring_panel.html
+++ b/templates/scoring_panel.html
@@ -51,7 +51,7 @@
   </div>
   <div id="bottom-controls">
     <div class="counter-wrapper">
-      {{template "counter" (dict "id" "trough" "label" "L1 Coral" "auto_label" "Auto")}}
+      {{template "counter" (dict "id" "trough" "label" "L1 Coral" "has_auto" true)}}
     </div>
     <button id="edit-auto" onclick="toggleEditAuto();" ontouchstart disabled></button>
     <div class="counter-wrapper">
@@ -130,10 +130,11 @@
 <div id="{{.id}}" class="counter">
   <button class="counter-decrement scoring-button" onclick="handleCounterClick('{{.id}}', -1);" ontouchstart disabled>-1</button>
   <div class="counter-status">
-    {{if .auto_label}}
-      <div class="counter-auto-row">{{.auto_label}}: <span class="counter-auto-value">0</span></div>
+    {{if .has_auto}}
+      <div class="counter-main-clone">Teleop: <span class="counter-value">0</span></div>
+      <div class="counter-auto-row">Auto: <span class="counter-auto-value">0</span></div>
     {{end}}
-    <div class="counter-value">0</div>
+    <div class="counter-value counter-main-value">0</div>
     <div class="counter-label">{{.label}}</div>
   </div>
   <button class="counter-increment scoring-button" onclick="handleCounterClick('{{.id}}', 1);" ontouchstart disabled>+1</button>


### PR DESCRIPTION
Swap the layout of the L1 coral counter to put the auto count in large numbers when inputting autonomous scores.