### PR TITLE
Add Count Mode to Alliance Station Displays

### DIFF
--- a/static/css/alliance_station_display.css
+++ b/static/css/alliance_station_display.css
@@ -19,6 +19,9 @@ body[data-mode=logo] {
 body[data-mode=fieldReset] {
   background-color: #0a3;
 }
+body[data-mode=signalCount] {
+  background-color: #90c;
+}
 
 /* Switching Modes */
 .mode {
@@ -31,6 +34,9 @@ body[data-mode=match] .mode#match {
   display: block;
 }
 body[data-mode=fieldReset] .mode#fieldReset {
+  display: table;
+}
+body[data-mode=signalCount] .mode#signalCount {
   display: table;
 }
 body[data-mode=timeout] .mode#match {
@@ -55,6 +61,20 @@ body[data-mode=timeout] .mode#match {
   height: 100%;
 }
 #fieldReset div {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 350px;
+  line-height: 350px;
+}
+
+/* Signal Count Mode */
+#signalCount {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+#signalCount div {
   display: table-cell;
   vertical-align: middle;
   text-align: center;

--- a/templates/alliance_station_display.html
+++ b/templates/alliance_station_display.html
@@ -33,6 +33,7 @@
       <img id="logoImg" src="/static/img/alliance-station-logo.png" alt="logo" />
     </div>
     <div id="fieldReset" class="mode"><div>FIELD<br />RESET</div></div>
+    <div id="signalCount" class="mode"><div>COUNT</div></div>
     <script src="/static/js/lib/jquery.min.js"></script>
     <script src="/static/js/lib/jquery.json-2.4.min.js"></script>
     <script src="/static/js/lib/jquery.websocket-0.0.1.js"></script>

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -208,6 +208,12 @@
                        onclick="setAllianceStationDisplay();" id="fieldResetRadio"> Field Reset
               </label>
             </div>
+            <div>
+              <label>
+                <input type="radio" name="allianceStationDisplay" value="signalCount"
+                       onclick="setAllianceStationDisplay();" id="fieldResetRadio"> Signal Count
+              </label>
+            </div>
           </div>
           <h6 class="mt-4">Shown Match Result</h6>
           <span class="badge badge-saved-match" id="savedMatchName">None</span>

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -287,6 +287,8 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 				continue
 			}
 			web.arena.FieldVolunteers = true
+			web.arena.AllianceStationDisplayMode = "signalCount"
+			web.arena.AllianceStationDisplayModeNotifier.Notify()
 		case "signalReset":
 			if web.arena.MatchState != field.PostMatch && web.arena.MatchState != field.PreMatch {
 				// Don't allow clearing the field until the match is over.

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -200,6 +200,8 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 				continue
 			}
 			web.arena.FieldVolunteers = true
+			web.arena.AllianceStationDisplayMode = "signalCount"
+			web.arena.AllianceStationDisplayModeNotifier.Notify()
 		case "signalReset":
 			if web.arena.MatchState != field.PostMatch {
 				// Don't allow clearing the field until the match is over.


### PR DESCRIPTION
For systems that don't use the Cypress Team Signs these updates add the Purple "Count" display on the Alliance Station Signs.
![image](https://github.com/user-attachments/assets/4cb03115-cea5-4443-ad4f-cf12d42ce9c5)
