### PR TITLE
Fix issue observed at 2025cafb

### DIFF
--- a/static/js/field_monitor_display.js
+++ b/static/js/field_monitor_display.js
@@ -106,7 +106,10 @@ const handleArenaStatus = function (data) {
       } else {
         teamRobotElement.text("RIO");
       }
-      teamBatteryElement.text(dsConn.BatteryPercentage.toFixed(1) + "V");
+      teamBatteryElement.text(
+        dsConn.BatteryPercentage == null // null or undefined
+          ? "N/A"
+          : dsConn.BatteryPercentage.toFixed(1) + "V");
 
       const btuOkay = wifiStatus.MBits < highBtuThreshold && dsConn.RobotLinked;
       teamStatsElement.attr("data-status-ok", btuOkay);


### PR DESCRIPTION
During 2025cafb, we observed that the field monitor display was crashing on this line. This appeared to be because `BatteryPercentage` was unavailable. Making this change got our field monitor working again. We were not able to spend the time to debug why the value was unavailable.