### PR TITLE
Adjust teleop L1 coral count when adjusting auto L1 coral

### DIFF
--- a/static/js/scoring_panel.js
+++ b/static/js/scoring_panel.js
@@ -206,7 +206,7 @@ const handleRealtimeScore = function (data) {
 const handleCounterClick = function (command, adjustment) {
   websocket.send(command, {
     Adjustment: adjustment,
-    Current: !editingAuto,
+    Current: true,
     Autonomous: !inTeleop || editingAuto,
     NearSide: nearSide
   });


### PR DESCRIPTION
Change the behavior of the scoring panels when editing the autonomous L1 coral count outside of auto. Now when adding/removing coral from auto, it also adjusts the teleop count by the same amount.

The existing behavior has led to confusion and mis-scores a few times, this seems more in line with what scorers are expecting.