### PR TITLE
Minor improvements from Sunset Showdown

### DIFF
--- a/static/css/scoring_panel.css
+++ b/static/css/scoring_panel.css
@@ -255,6 +255,13 @@ main {
   justify-content: space-around;
 }
 
+#l1-total {
+  margin-top: 10px;
+  color: var(--text-active);
+  font-size: 18pt;
+  font-weight: bold;
+}
+
 #commit {
   flex: 1 1 0%;
   height: 100%;

--- a/static/js/field_monitor_display.js
+++ b/static/js/field_monitor_display.js
@@ -99,13 +99,15 @@ const handleArenaStatus = function (data) {
       teamRadioElement.attr("data-status-ok", radioOkay);
 
       // Format the robot status box.
-      const robotOkay = dsConn.BatteryVoltage > lowBatteryThreshold && dsConn.RobotLinked;
-      teamRobotElement.attr("data-status-ok", robotOkay);
+      const rioOkay = dsConn.RobotLinked;
+      teamRobotElement.attr("data-status-ok", rioOkay);
       if (stationStatus.DsConn.SecondsSinceLastRobotLink > 1 && stationStatus.DsConn.SecondsSinceLastRobotLink < 1000) {
         teamRobotElement.text(stationStatus.DsConn.SecondsSinceLastRobotLink.toFixed());
       } else {
         teamRobotElement.text("RIO");
       }
+      const batteryOkay = dsConn.BatteryVoltage > lowBatteryThreshold && dsConn.RobotLinked;
+      teamBatteryElement.attr("data-status-ok", batteryOkay);
       teamBatteryElement.text(dsConn.BatteryVoltage.toFixed(1) + "V");
 
       const btuOkay = wifiStatus.MBits < highBtuThreshold && dsConn.RobotLinked;

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -121,6 +121,10 @@ const handleRealtimeScore = function (data) {
     let l2_total = score.Reef.Branches[0].filter(Boolean).length;
     let l3_total = score.Reef.Branches[1].filter(Boolean).length;
     let l4_total = score.Reef.Branches[2].filter(Boolean).length;
+    let l1_auto_total = score.Reef.AutoTroughNear + score.Reef.AutoTroughFar;
+    let l2_auto_total = score.Reef.AutoBranches[0].filter(Boolean).length;
+    let l3_auto_total = score.Reef.AutoBranches[1].filter(Boolean).length;
+    let l4_auto_total = score.Reef.AutoBranches[2].filter(Boolean).length;
 
     let scoreRoot = `${alliance}ScoreSummary`;
     $(`#${scoreRoot} .team-1-leave`).text(score.LeaveStatuses[0] ? "✓" : "❌");
@@ -133,6 +137,10 @@ const handleRealtimeScore = function (data) {
     $(`#${scoreRoot} .coral-l2`).text(l2_total);
     $(`#${scoreRoot} .coral-l3`).text(l3_total);
     $(`#${scoreRoot} .coral-l4`).text(l4_total);
+    $(`#${scoreRoot} .coral-l1-auto`).text(l1_auto_total);
+    $(`#${scoreRoot} .coral-l2-auto`).text(l2_auto_total);
+    $(`#${scoreRoot} .coral-l3-auto`).text(l3_auto_total);
+    $(`#${scoreRoot} .coral-l4-auto`).text(l4_auto_total);
     $(`#${scoreRoot} .processor`).text(score.ProcessorAlgae);
     $(`#${scoreRoot} .barge`).text(score.BargeAlgae);
   }

--- a/static/js/scoring_panel.js
+++ b/static/js/scoring_panel.js
@@ -184,8 +184,12 @@ const handleRealtimeScore = function (data) {
     }
   }
 
+  const l1Total = score.Reef.TroughNear + score.Reef.TroughFar;
+  $("#l1-total-count").text(l1Total);
+  
   $(`#barge .counter-value`).text(score.BargeAlgae);
   $(`#processor .counter-value`).text(score.ProcessorAlgae);
+
   if (nearSide) {
     $(`#trough .counter-value`).text(score.Reef.TroughNear);
     $(`#trough .counter-auto-value`).text(score.Reef.AutoTroughNear);

--- a/templates/referee_panel.html
+++ b/templates/referee_panel.html
@@ -83,6 +83,11 @@ UI for entering and tracking fouls and red/yellow cards.
   <div class="wide-row">
     <span class="coral-l1">0</span> / <span class="coral-l2">0</span> / <span class="coral-l3">0</span> /
     <span class="coral-l4">0</span>
+    <br />
+    <span style="color: yellow">
+      <span class="coral-l1-auto">0</span> / <span class="coral-l2-auto">0</span> / <span class="coral-l3-auto">0</span> /
+      <span class="coral-l4-auto">0</span>
+    </span>
   </div>
 
   <div class="label">Algae</div>

--- a/templates/scoring_panel.html
+++ b/templates/scoring_panel.html
@@ -65,6 +65,7 @@ UI for entering realtime scores.
     </div>
     <button id="fouls-button" class="scoring-button" onclick="showFoulsDialog();" ontouchstart disabled>Fouls</button>
   </div>
+  <div id="l1-total">L1 Coral Total: <span id="l1-total-count">0</span></div>
 </main>
 
 <svg id="reef-graphics" style="display:none">

--- a/web/match_review.go
+++ b/web/match_review.go
@@ -135,6 +135,8 @@ func (web *Web) matchReviewEditPostHandler(w http.ResponseWriter, r *http.Reques
 		web.arena.RedRealtimeScore.Cards = matchResult.RedCards
 		web.arena.BlueRealtimeScore.Cards = matchResult.BlueCards
 
+		web.arena.RealtimeScoreNotifier.Notify()
+
 		http.Redirect(w, r, "/match_play", 303)
 	} else {
 		err = web.commitMatchScore(match, &matchResult, true)


### PR DESCRIPTION
Various miscellaneous improvements from sunshow2025

* Fix HR panel and scoring panels not updating if the scorekeeper edits scores
* Add auto coral counts to the HR scoring summary
* Add the combined L1 coral count from near and far to the scoring panels (contributed by @nwfisher, thanks!)
* Adjust the field monitor to set battery status color based on battery voltage (rather than battery voltage contributing to rio status)