### PR TITLE
Add red italic placeholder styles for input fields in the form

### DIFF
--- a/static/css/cheesy-arena.css
+++ b/static/css/cheesy-arena.css
@@ -166,3 +166,10 @@ input[data-changed="true"], select[data-changed="true"] {
 #testMatchSettings {
   display: none;
 }
+
+/* Placeholder styles for input fields*/
+.col-lg-6 input::placeholder {
+    color: #ff0000; /* Red placeholder text */
+    font-style: italic;
+    opacity: 0.4;
+}

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -53,7 +53,7 @@ UI for configuring event settings.
               <div class="row mb-3">
                 <label class="col-lg-6 control-label">Name</label>
                 <div class="col-lg-6">
-                  <input type="text" class="form-control" name="name" placeholder="{{.Name}}">
+                  <input type="text" class="form-control" name="name" value="{{.Name}}" placeholder="{{.Name}}">
                 </div>
               </div>
               <div class="row mb-3">


### PR DESCRIPTION
Simple stylizing to make the place holder text a bit more obvious, they either need to be set or are not set #240 
<img width="691" height="130" alt="image" src="https://github.com/user-attachments/assets/83f92a5f-13b5-4a21-b411-0e971fd75451" />
