### PR TITLE
Configuring SCC ssh terminal mode so EOL characters work properly for…

### DIFF
--- a/network/sccswitch.go
+++ b/network/sccswitch.go
@@ -110,6 +110,11 @@ func (scc *SCCSwitch) runCommandSequence(commands []string) (string, error) {
 		return "", fmt.Errorf("failed to create input pipe: %w", err)
 	}
 
+	modes := ssh.TerminalModes{ssh.ECHO: 0}
+	if err := session.RequestPty("vt100", 80, 40, modes); err != nil {
+		return "", fmt.Errorf("failed to configure shell: %w", err)
+	}
+
 	// Launch the switch's interactive shell
 	err = session.Shell()
 	if err != nil {

--- a/network/sccswitch_test.go
+++ b/network/sccswitch_test.go
@@ -91,8 +91,13 @@ func mockSSHSwitch(t *testing.T, port int, username, password string, commands *
 		assert.Nil(t, err)
 		defer channel.Close()
 
-		// Wait for the client to request a shell
+		// Wait for the client to request a PTY
 		req := <-requests
+		assert.Equal(t, "pty-req", req.Type)
+		req.Reply(true, nil)
+
+		// Wait for the client to request a shell
+		req = <-requests
 		assert.Equal(t, "shell", req.Type)
 		req.Reply(true, nil)
 


### PR DESCRIPTION
… Stride switches.

The stride switches we use we not accepting commands due to mishandling the `\r`

The command being sent was 

```
port 1 admin disabled\r
```

This would result in the following error.

```
505 'disabled
' is not a valid admin setting.
```

Using `RequestPty` properly sets up the interactive PTY.  While Cisco HW is more forgiving and doesn't require it I back tested this with a 3560-C Series switch I had and it works as expected.