### PR TITLE
Add a unique ID field to fouls

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -96,6 +96,7 @@ type Arena struct {
 	soundsPlayed                      map[*game.MatchSound]struct{}
 	breakDescription                  string
 	preloadedTeams                    *[6]*model.Team
+	NextFoulId                        int
 }
 
 type AllianceStation struct {
@@ -331,6 +332,7 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.BlueRealtimeScore = NewRealtimeScore()
 	arena.ScoringPanelRegistry.resetScoreCommitted()
 	arena.Plc.ResetMatch()
+	arena.NextFoulId = 1
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()

--- a/game/foul.go
+++ b/game/foul.go
@@ -6,6 +6,7 @@
 package game
 
 type Foul struct {
+	FoulId  int
 	IsMajor bool
 	TeamId  int
 	RuleId  int

--- a/game/score_test.go
+++ b/game/score_test.go
@@ -179,7 +179,7 @@ func TestScoreCoralBonusRankingPoint(t *testing.T) {
 	assert.Equal(t, true, blueScoreSummary.CoralBonusRankingPoint)
 
 	// Check that G206 disqualifies the alliance from the Coral bonus.
-	blueScore.Fouls = []Foul{{RuleId: 1}}
+	blueScore.Fouls = []Foul{{FoulId: 1, RuleId: 1}}
 	redScoreSummary = redScore.Summarize(blueScore)
 	blueScoreSummary = blueScore.Summarize(redScore)
 	assert.Equal(t, 0, redScoreSummary.FoulPoints)

--- a/game/test_helpers.go
+++ b/game/test_helpers.go
@@ -7,13 +7,13 @@ package game
 
 func TestScore1() *Score {
 	fouls := []Foul{
-		{true, 25, 16},
-		{false, 1868, 13},
-		{false, 1868, 13},
-		{true, 25, 15},
-		{true, 25, 15},
-		{true, 25, 15},
-		{true, 25, 15},
+		{1, true, 25, 16},
+		{2, false, 1868, 13},
+		{3, false, 1868, 13},
+		{4, true, 25, 15},
+		{5, true, 25, 15},
+		{6, true, 25, 15},
+		{7, true, 25, 15},
 	}
 	return &Score{
 		RobotsBypassed: [3]bool{false, false, true},

--- a/web/match_play_test.go
+++ b/web/match_play_test.go
@@ -127,10 +127,10 @@ func TestCommitTiebreak(t *testing.T) {
 		// These should all be fields that aren't part of the tiebreaker.
 		RedScore: &game.Score{
 			Reef:  game.Reef{TroughFar: 1},
-			Fouls: []game.Foul{{IsMajor: false}, {IsMajor: false}},
+			Fouls: []game.Foul{{FoulId: 1, IsMajor: false}, {FoulId: 2, IsMajor: false}},
 		},
 		BlueScore: &game.Score{
-			Fouls: []game.Foul{{IsMajor: false}},
+			Fouls: []game.Foul{{FoulId: 3, IsMajor: false}},
 		},
 	}
 
@@ -156,7 +156,7 @@ func TestCommitTiebreak(t *testing.T) {
 
 	// Change the score to still be equal nominally but trigger the tiebreaker criteria.
 	matchResult.BlueScore.ProcessorAlgae = 1
-	matchResult.BlueScore.Fouls = []game.Foul{{IsMajor: false}, {IsMajor: true}}
+	matchResult.BlueScore.Fouls = []game.Foul{{FoulId: 3, IsMajor: false}, {FoulId: 4, IsMajor: true}}
 
 	// Sanity check that the test scores are equal; they will need to be updated accordingly for each new game.
 	assert.Equal(

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -113,7 +113,8 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			}
 
 			// Add the foul to the correct alliance's list.
-			foul := game.Foul{IsMajor: args.IsMajor}
+			foul := game.Foul{FoulId: web.arena.NextFoulId, IsMajor: args.IsMajor}
+			web.arena.NextFoulId++
 			if args.Alliance == "red" {
 				web.arena.RedRealtimeScore.CurrentScore.Fouls =
 					append(web.arena.RedRealtimeScore.CurrentScore.Fouls, foul)

--- a/web/scoring_panel.go
+++ b/web/scoring_panel.go
@@ -236,7 +236,8 @@ func (web *Web) scoringPanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			}
 
 			// Add the foul to the correct alliance's list.
-			foul := game.Foul{IsMajor: args.IsMajor}
+			foul := game.Foul{FoulId: web.arena.NextFoulId, IsMajor: args.IsMajor}
+			web.arena.NextFoulId++
 			if args.Alliance == "red" {
 				web.arena.RedRealtimeScore.CurrentScore.Fouls =
 					append(web.arena.RedRealtimeScore.CurrentScore.Fouls, foul)


### PR DESCRIPTION
Add a unique ID field to the foul structure to enable tracking modifications to fouls.

The main goal of this is to allow external VAR tooling to record fouls being entered and recognize edits/deletions made by the head ref, but it generalizes to anything else connected to realtime score data (eg this could be extended to allow scorer panels to identify which fouls are theirs and provide a remove foul button). Without this, complex heuristics are needed to identify which foul was edited or removed when a change is made.

There's a follow-up change that may be useful of changing the referee panels to edit fouls based on this ID, rather than on list index. Currently there are race conditions where adjustments to the foul list can change which foul is modified by a websocket request, since everything is keyed to list index right now.