### PR TITLE
Alliance selection improvements

### DIFF
--- a/static/js/alliance_selection.js
+++ b/static/js/alliance_selection.js
@@ -16,10 +16,20 @@ const startTimer = function () {
   websocket.send("startTimer");
 };
 
-// Sends a websocket message to stop and hide the timer.
+// Sends a websocket message to hide the timer.
+const hideTimer = function() {
+  websocket.send("hideTimer");
+}
+
+// Sends a websocket message to stop the timer.
 const stopTimer = function () {
   websocket.send("stopTimer");
 }
+
+// Sends a websocket message to restart the timer. 
+const restartTimer = function () {
+  websocket.send("restartTimer");
+};
 
 // Handles a websocket message to update the alliance selection status.
 const handleAllianceSelection = function (data) {

--- a/templates/alliance_selection.html
+++ b/templates/alliance_selection.html
@@ -89,7 +89,7 @@ UI for controlling the alliance selection process.
         <p>Timer is hidden on the audience overlay until the Start/Show button below is pressed.</p>
         <div class="row">
           <label class="col-lg-4 control-label">Time limit<br/>(0 = disabled)</label>
-          <div class="col-lg-8">
+          <div class="col-lg-4">
             <label>
               <input type="radio" name="timeLimitSec" value="45" onclick="setTimer(this);">
               45 seconds (1st round)
@@ -109,7 +109,9 @@ UI for controlling the alliance selection process.
         <div class="mt-3 row justify-content-center">
           <div class="col-lg-8 text-center">
             <button type="button" class="btn btn-success" onclick="startTimer();">Start/Show Timer</button>
-            <button type="button" class="btn btn-secondary" onclick="stopTimer();">Stop/Hide Timer</button>
+            <button type="button" class="btn btn-danger" onclick="stopTimer();">Stop Timer</button>
+            <button type="button" class="btn btn-info" onclick="restartTimer();">Reset/Show Timer</button>
+            <button type="button" class="btn btn-secondary" onclick="hideTimer();">Stop/Hide Timer</button>
           </div>
         </div>
       </div>

--- a/templates/alliance_selection.html
+++ b/templates/alliance_selection.html
@@ -76,20 +76,19 @@ UI for controlling the alliance selection process.
           {{end}}
         </tbody>
       </table>
-      Hint: Press 'Enter' after entering each team number for easiest use.
+      Press <kbd>Enter</kbd> after each pick is confirmed
       <div class="card card-body bg-body-secondary mt-4">
         <div class="row">
           <div class="col-lg-8">
-            <legend>Selection Timer</legend>
+            <legend>Timer</legend>
           </div>
           <div class="col-lg-4 text-end">
             <legend id="timer"></legend>
           </div>
         </div>
-        <p>Timer is hidden on the audience overlay until the Start/Show button below is pressed.</p>
         <div class="row">
-          <label class="col-lg-4 control-label">Time limit<br/>(0 = disabled)</label>
-          <div class="col-lg-4">
+          <label class="col-lg-4 control-label">Duration</label>
+          <div class="col-lg-8">
             <label>
               <input type="radio" name="timeLimitSec" value="45" onclick="setTimer(this);">
               45 seconds (1st round)
@@ -100,18 +99,22 @@ UI for controlling the alliance selection process.
             </label>
             <label>
               <input type="radio" name="timeLimitSec" value="120" onclick="setTimer(this);">
-              120 seconds (break between rounds)
+              120 seconds (between rounds)
             </label>
             <input type="text" class="form-control mt-2" id="timeLimitSecInput" name="timeLimitSec"
               value="{{.TimeLimitSec}}" onblur="setTimer(this);">
           </div>
         </div>
         <div class="mt-3 row justify-content-center">
+          <div class="col-lg-8 gap-3 d-flex justify-content-center">
+            <button type="button" class="btn btn-success" onclick="startTimer();">Start</button>
+            <button type="button" class="btn btn-warning" onclick="stopTimer();">Pause</button>
+            <button type="button" class="btn btn-danger" onclick="restartTimer();">Reset</button>
+          </div>
+        </div>
+        <div class="mt-5 row justify-content-center">
           <div class="col-lg-8 text-center">
-            <button type="button" class="btn btn-success" onclick="startTimer();">Start/Show Timer</button>
-            <button type="button" class="btn btn-danger" onclick="stopTimer();">Stop Timer</button>
-            <button type="button" class="btn btn-info" onclick="restartTimer();">Reset/Show Timer</button>
-            <button type="button" class="btn btn-secondary" onclick="hideTimer();">Stop/Hide Timer</button>
+            <button type="button" class="btn btn-secondary" onclick="hideTimer();">Hide</button>
           </div>
         </div>
       </div>

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -301,23 +301,34 @@ func (web *Web) allianceSelectionWebsocketHandler(w http.ResponseWriter, r *http
 		case "startTimer":
 			if !web.arena.AllianceSelectionShowTimer {
 				web.arena.AllianceSelectionShowTimer = true
-				web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
-				web.arena.AllianceSelectionNotifier.Notify()
-				allianceSelectionTicker = time.NewTicker(time.Second)
-				go func() {
-					for range allianceSelectionTicker.C {
-						web.arena.AllianceSelectionTimeRemainingSec--
-						web.arena.AllianceSelectionNotifier.Notify()
-						if web.arena.AllianceSelectionTimeRemainingSec == 5 {
-							web.arena.PlaySound("pick_clock")
-						} else if web.arena.AllianceSelectionTimeRemainingSec == 0 {
-							allianceSelectionTicker.Stop()
-							web.arena.PlaySound("pick_clock_expired")
-						}
-					}
-				}()
 			}
+			if web.arena.AllianceSelectionTimeRemainingSec == 0 {
+				web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
+			}
+			web.arena.AllianceSelectionNotifier.Notify()
+			allianceSelectionTicker = time.NewTicker(time.Second)
+			go func() {
+				for range allianceSelectionTicker.C {
+					web.arena.AllianceSelectionTimeRemainingSec--
+					web.arena.AllianceSelectionNotifier.Notify()
+					if web.arena.AllianceSelectionTimeRemainingSec == 5 {
+						web.arena.PlaySound("pick_clock")
+					} else if web.arena.AllianceSelectionTimeRemainingSec == 0 {
+						allianceSelectionTicker.Stop()
+						web.arena.PlaySound("pick_clock_expired")
+					}
+				}
+			}()
 		case "stopTimer":
+			allianceSelectionTicker.Stop()
+			web.arena.AllianceSelectionNotifier.Notify()
+		case "restartTimer":
+			if !web.arena.AllianceSelectionShowTimer {
+				web.arena.AllianceSelectionShowTimer = true
+			}
+			web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
+			web.arena.AllianceSelectionNotifier.Notify()
+		case "hideTimer":
 			allianceSelectionTicker.Stop()
 			web.arena.AllianceSelectionShowTimer = false
 			web.arena.AllianceSelectionTimeRemainingSec = 0

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -299,12 +299,13 @@ func (web *Web) allianceSelectionWebsocketHandler(w http.ResponseWriter, r *http
 				ws.WriteError("Invalid time limit value.")
 			}
 		case "startTimer":
-			if !web.arena.AllianceSelectionShowTimer {
-				web.arena.AllianceSelectionShowTimer = true
+			if allianceSelectionTicker != nil {
+				allianceSelectionTicker.Stop()
 			}
 			if web.arena.AllianceSelectionTimeRemainingSec == 0 {
 				web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
 			}
+			web.arena.AllianceSelectionShowTimer = true
 			web.arena.AllianceSelectionNotifier.Notify()
 			allianceSelectionTicker = time.NewTicker(time.Second)
 			go func() {
@@ -320,16 +321,17 @@ func (web *Web) allianceSelectionWebsocketHandler(w http.ResponseWriter, r *http
 				}
 			}()
 		case "stopTimer":
-			allianceSelectionTicker.Stop()
-			web.arena.AllianceSelectionNotifier.Notify()
-		case "restartTimer":
-			if !web.arena.AllianceSelectionShowTimer {
-				web.arena.AllianceSelectionShowTimer = true
+			if allianceSelectionTicker != nil {
+				allianceSelectionTicker.Stop()
 			}
+		case "restartTimer":
+			web.arena.AllianceSelectionShowTimer = true
 			web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
 			web.arena.AllianceSelectionNotifier.Notify()
 		case "hideTimer":
-			allianceSelectionTicker.Stop()
+			if allianceSelectionTicker != nil {
+				allianceSelectionTicker.Stop()
+			}
 			web.arena.AllianceSelectionShowTimer = false
 			web.arena.AllianceSelectionTimeRemainingSec = 0
 			web.arena.AllianceSelectionNotifier.Notify()

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -304,7 +304,7 @@ func (web *Web) allianceSelectionWebsocketHandler(w http.ResponseWriter, r *http
 			}
 			if web.arena.AllianceSelectionTimeRemainingSec == 0 {
 				web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec
-			  currentAllianceSelectionTimeLimitSec = allianceSelectionTimeLimitSec
+				currentAllianceSelectionTimeLimitSec = allianceSelectionTimeLimitSec
 			}
 			web.arena.AllianceSelectionShowTimer = true
 			web.arena.AllianceSelectionNotifier.Notify()

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -89,12 +89,6 @@ func (web *Web) allianceSelectionPostHandler(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	if allianceSelectionTicker != nil {
-		allianceSelectionTicker.Stop()
-		web.arena.AllianceSelectionShowTimer = false
-		web.arena.AllianceSelectionTimeRemainingSec = 0
-	}
-
 	web.arena.AllianceSelectionNotifier.Notify()
 	http.Redirect(w, r, "/alliance_selection", 303)
 }

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -332,6 +332,7 @@ func (web *Web) allianceSelectionWebsocketHandler(w http.ResponseWriter, r *http
 			if allianceSelectionTicker != nil {
 				allianceSelectionTicker.Stop()
 			}
+			web.arena.AllianceSelectionNotifier.Notify()
 		case "restartTimer":
 			web.arena.AllianceSelectionShowTimer = true
 			web.arena.AllianceSelectionTimeRemainingSec = allianceSelectionTimeLimitSec

--- a/web/alliance_selection_test.go
+++ b/web/alliance_selection_test.go
@@ -4,13 +4,14 @@
 package web
 
 import (
+	"testing"
+
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/Team254/cheesy-arena/websocket"
 	gorillawebsocket "github.com/gorilla/websocket"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestAllianceSelection(t *testing.T) {
@@ -338,8 +339,11 @@ func TestAllianceSelectionWebsocket(t *testing.T) {
 	assert.Equal(t, true, allianceSelectionMessage.ShowTimer)
 	ws.Write("stopTimer", nil)
 	assert.Nil(t, mapstructure.Decode(readWebsocketType(t, ws, "allianceSelection"), &allianceSelectionMessage))
+	assert.Equal(t, true, allianceSelectionMessage.ShowTimer)
+	ws.Write("hideTimer", nil)
+	assert.Nil(t, mapstructure.Decode(readWebsocketType(t, ws, "allianceSelection"), &allianceSelectionMessage))
 	assert.Equal(t, false, allianceSelectionMessage.ShowTimer)
-	ws.Write("startTimer", nil)
+	ws.Write("restartTimer", nil)
 	assert.Nil(t, mapstructure.Decode(readWebsocketType(t, ws, "allianceSelection"), &allianceSelectionMessage))
 	assert.Equal(t, true, allianceSelectionMessage.ShowTimer)
 }


### PR DESCRIPTION
- Based on #242 
- Fixes a bug in #242 that could cause multiple timers to run at the same time
- Fixes bugs in #242 that caused errors when pausing/stopping a timer that was never started
- Simplifies the timer UX (reduces text on buttons, updates colors):
<img width="1334" height="997" alt="Screenshot 2025-11-15 082500" src="https://github.com/user-attachments/assets/23f2c366-1516-40ee-a232-dfba9ae09f6c" />

- Removes logic for stopping the timer when a pick is made
  - This was causing us problems at Madtown because we were using a separate person to run the timer and confirming the team number frequently took the scorekeeper a while due to having to look up the B-team numbers. The timer for the next pick should be able to be started when the emcee says "you're on the clock" even if that happens before the previous pick is confirmed in FMS
- Disables pick clock sounds during 2-minute break between rounds
  - The end of the 2-minute timer just causes another timer to start, no need to alert teams with the scary noises