### PR TITLE
Send event code to DS

### DIFF
--- a/field/driver_station_connection.go
+++ b/field/driver_station_connection.go
@@ -405,16 +405,16 @@ func (arena *Arena) serveDriverStations(listener net.Listener) {
 		}
 
 		// Write event code here. We need to strip any numbers off the front if it has it.
+		// We also need to limit to 62 characters.
 		eventName := arena.EventSettings.TbaEventCode
 		if len(eventName) > 0 {
+			trimIndex := 0
+			for trimIndex < len(eventName) && eventName[trimIndex] >= '0' && eventName[trimIndex] <= '9' {
+				trimIndex++
+			}
+			eventName = eventName[trimIndex:]
 			if len(eventName) > 62 {
 				eventName = eventName[:62]
-			}
-			for i, character := range eventName {
-				if character < '0' || character > '9' {
-					eventName = eventName[i:]
-					break
-				}
 			}
 			if len(eventName) > 0 {
 				eventNamePacket := make([]byte, 4+len(eventName))
@@ -422,9 +422,7 @@ func (arena *Arena) serveDriverStations(listener net.Listener) {
 				eventNamePacket[1] = byte(len(eventName) + 2)
 				eventNamePacket[2] = 20 // Packet type for event name
 				eventNamePacket[3] = byte(len(eventName))
-				for i, character := range eventName {
-					eventNamePacket[4+i] = byte(character)
-				}
+				copy(eventNamePacket[4:], []byte(eventName))
 				_, err = tcpConn.Write(eventNamePacket)
 				if err != nil {
 					log.Printf("Error sending event name packet: %v", err)

--- a/field/driver_station_connection.go
+++ b/field/driver_station_connection.go
@@ -404,6 +404,36 @@ func (arena *Arena) serveDriverStations(listener net.Listener) {
 			continue
 		}
 
+		// Write event code here. We need to strip any numbers off the front if it has it.
+		eventName := arena.EventSettings.TbaEventCode
+		if len(eventName) > 0 {
+			if len(eventName) > 62 {
+				eventName = eventName[:62]
+			}
+			for i, character := range eventName {
+				if character < '0' || character > '9' {
+					eventName = eventName[i:]
+					break
+				}
+			}
+			if len(eventName) > 0 {
+				eventNamePacket := make([]byte, 4+len(eventName))
+				eventNamePacket[0] = 0
+				eventNamePacket[1] = byte(len(eventName) + 2)
+				eventNamePacket[2] = 20 // Packet type for event name
+				eventNamePacket[3] = byte(len(eventName))
+				for i, character := range eventName {
+					eventNamePacket[4+i] = byte(character)
+				}
+				_, err = tcpConn.Write(eventNamePacket)
+				if err != nil {
+					log.Printf("Error sending event name packet: %v", err)
+					tcpConn.Close()
+					continue
+				}
+			}
+		}
+
 		dsConn, err := newDriverStationConnection(teamId, assignedStation, tcpConn, arena.EventSettings.UseLiteUdpPort)
 		if err != nil {
 			log.Printf("Error registering driver station connection: %v", err)

--- a/field/driver_station_connection_test.go
+++ b/field/driver_station_connection_test.go
@@ -159,7 +159,7 @@ func TestListenForDriverStations(t *testing.T) {
 		dataSend := [5]byte{0, 3, 29, 0, 0}
 		tcpConn.Write(dataSend[:])
 		var dataReceived [100]byte
-		_, err = tcpConn.Read(dataReceived[:])
+		_, err = readTaggedTcpPacket(tcpConn, dataReceived[:])
 		assert.NotNil(t, err)
 		tcpConn.Close()
 	}
@@ -170,7 +170,7 @@ func TestListenForDriverStations(t *testing.T) {
 		dataSend := [5]byte{0, 3, 24, 5, 223}
 		tcpConn.Write(dataSend[:])
 		var dataReceived [5]byte
-		count, err := tcpConn.Read(dataReceived[:])
+		count, err := readTaggedTcpPacket(tcpConn, dataReceived[:])
 		assert.Nil(t, err)
 		assert.Equal(t, count, 5)
 		assert.Equal(t, [5]byte{0, 3, 25, 0, 2}, dataReceived)
@@ -183,13 +183,31 @@ func TestListenForDriverStations(t *testing.T) {
 	// Connect as a team in the current match with a fragmented initial packet.
 	tcpConn, err = net.Dial("tcp", serverAddress)
 	if assert.Nil(t, err) {
+		defer tcpConn.Close()
 		dataSend := [5]byte{0, 3, 24, 5, 223}
 		tcpConn.Write(dataSend[:1])
 		tcpConn.Write(dataSend[1:5])
 		var dataReceived [5]byte
-		_, err := tcpConn.Read(dataReceived[:])
+		count, err := readTaggedTcpPacket(tcpConn, dataReceived[:])
 		assert.Nil(t, err)
-		tcpConn.Close()
+		assert.Equal(t, count, 5)
+	}
+
+	// Set event name
+	arena.EventSettings.TbaEventCode = "2026CC"
+	tcpConn, err = net.Dial("tcp", serverAddress)
+	if assert.Nil(t, err) {
+		defer tcpConn.Close()
+		dataSend := [5]byte{0, 3, 24, 5, 223}
+		tcpConn.Write(dataSend[:])
+		var dataReceived [100]byte
+		_, err := readTaggedTcpPacket(tcpConn, dataReceived[:])
+		assert.Nil(t, err)
+		// Read event name
+		count, err := readTaggedTcpPacket(tcpConn, dataReceived[:])
+		assert.Nil(t, err)
+		assert.Equal(t, count, 6)
+		assert.Equal(t, []byte{0, 4, 20, 2, 67, 67}, dataReceived[:6])
 	}
 
 	tcpConn, err = net.Dial("tcp", serverAddress)
@@ -198,7 +216,7 @@ func TestListenForDriverStations(t *testing.T) {
 		dataSend := [5]byte{0, 3, 24, 5, 223}
 		tcpConn.Write(dataSend[:])
 		var dataReceived [5]byte
-		_, err = tcpConn.Read(dataReceived[:])
+		_, err = readTaggedTcpPacket(tcpConn, dataReceived[:])
 		assert.Nil(t, err)
 		assert.Equal(t, [5]byte{0, 3, 25, 4, 0}, dataReceived)
 
@@ -228,7 +246,7 @@ func TestListenForDriverStations_NetworkSecurityIgnoresNonFieldIp(t *testing.T) 
 		tcpConn.Write(dataSend[:])
 
 		var dataReceived [5]byte
-		_, err = tcpConn.Read(dataReceived[:])
+		_, err = readTaggedTcpPacket(tcpConn, dataReceived[:])
 		assert.Nil(t, err)
 		assert.Equal(t, [5]byte{0, 3, 25, 4, 0}, dataReceived)
 


### PR DESCRIPTION
The event code that is sent to the robots doesn't include the year, so it is stripped

Also had to update the tests to handle tagged packets properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event code information is now transmitted to driver stations during connection initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->