### PR TITLE
Add periodic task to check for updated Nexus lineup

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -27,7 +27,7 @@ const (
 	arenaLoopWarningMs       = 5
 	dsPacketPeriodMs         = 500
 	dsPacketWarningMs        = 550
-	periodicTaskPeriodSec    = 30
+	periodicTaskPeriodSec    = 15
 	matchEndScoreDwellSec    = 3
 	postTimeoutSec           = 4
 	preLoadNextMatchDelaySec = 5

--- a/field/arena.go
+++ b/field/arena.go
@@ -1231,10 +1231,39 @@ func (arena *Arena) positionPostMatchScoreReady(position string) bool {
 	return numPanels > 0 && arena.ScoringPanelRegistry.GetNumScoreCommitted(position) >= numPanels
 }
 
+func (arena *Arena) checkForNexusLineupChanges() {
+	if !arena.EventSettings.NexusEnabled || !arena.CurrentMatch.ShouldAllowNexusSubstitution() {
+		return
+	}
+
+	if arena.MatchState != PreMatch {
+		// Only check for an updated lineup pre-match.
+		return
+	}
+
+	lineup, err := arena.NexusClient.GetLineup(arena.CurrentMatch.TbaMatchKey)
+	if err == nil {
+		if !arena.CurrentMatch.IsLineupEqual(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5]) {
+			log.Printf("Found updated lineup from Nexus, substituting")
+			err = arena.SubstituteTeams(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5])
+			if err == nil {
+				log.Printf(
+					"Successfully updated lineup for match %s from Nexus: %v", arena.CurrentMatch.TbaMatchKey.String(), *lineup,
+				)
+			} else {
+				log.Printf("Failed to substitute teams using Nexus lineup: %s", err.Error())
+			}
+		}
+	} else {
+		log.Printf("Failed to load lineup from Nexus: %s", err.Error())
+	}
+}
+
 // Performs any actions that need to run at the interval specified by periodicTaskPeriodSec.
 func (arena *Arena) runPeriodicTasks() {
 	arena.updateEarlyLateMessage()
 	arena.purgeDisconnectedDisplays()
+	arena.checkForNexusLineupChanges()
 }
 
 // trussLightWarningSequence generates the sequence of truss light states during the "sonar ping" warning sound. It

--- a/field/arena.go
+++ b/field/arena.go
@@ -1231,8 +1231,8 @@ func (arena *Arena) positionPostMatchScoreReady(position string) bool {
 	return numPanels > 0 && arena.ScoringPanelRegistry.GetNumScoreCommitted(position) >= numPanels
 }
 
-func (arena *Arena) checkForNexusLineupChanges() {
-	if !arena.EventSettings.NexusEnabled || !arena.CurrentMatch.ShouldAllowNexusSubstitution() {
+func (arena *Arena) checkForUpdatedNexusLineup() {
+	if !(arena.EventSettings.NexusEnabled && arena.CurrentMatch.ShouldAllowNexusSubstitution()) {
 		return
 	}
 
@@ -1242,20 +1242,21 @@ func (arena *Arena) checkForNexusLineupChanges() {
 	}
 
 	lineup, err := arena.NexusClient.GetLineup(arena.CurrentMatch.TbaMatchKey)
-	if err == nil {
-		if !arena.CurrentMatch.IsLineupEqual(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5]) {
-			log.Printf("Found updated lineup from Nexus, substituting")
-			err = arena.SubstituteTeams(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5])
-			if err == nil {
-				log.Printf(
-					"Successfully updated lineup for match %s from Nexus: %v", arena.CurrentMatch.TbaMatchKey.String(), *lineup,
-				)
-			} else {
-				log.Printf("Failed to substitute teams using Nexus lineup: %s", err.Error())
-			}
-		}
-	} else {
+	if err != nil {
 		log.Printf("Failed to load lineup from Nexus: %s", err.Error())
+		return
+	}
+
+	if !arena.CurrentMatch.IsLineupEqual(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5]) {
+		log.Printf("Got updated lineup from Nexus, substituting")
+		err = arena.SubstituteTeams(lineup[0], lineup[1], lineup[2], lineup[3], lineup[4], lineup[5])
+		if err != nil {
+			log.Printf("Failed to substitute teams using Nexus lineup: %s", err.Error())
+			return
+		}
+		log.Printf(
+			"Successfully updated lineup for match %s from Nexus: %v", arena.CurrentMatch.TbaMatchKey.String(), *lineup,
+		)
 	}
 }
 
@@ -1263,7 +1264,7 @@ func (arena *Arena) checkForNexusLineupChanges() {
 func (arena *Arena) runPeriodicTasks() {
 	arena.updateEarlyLateMessage()
 	arena.purgeDisconnectedDisplays()
-	arena.checkForNexusLineupChanges()
+	arena.checkForUpdatedNexusLineup()
 }
 
 // trussLightWarningSequence generates the sequence of truss light states during the "sonar ping" warning sound. It

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -178,6 +178,10 @@ func (arena *Arena) GenerateMatchLoadMessage() any {
 		}
 	}
 
+	// Don't allow manual substitution of practice/playoff teams when they would be automatically overwritten by Nexus.
+	var allowManualSubstitution = arena.CurrentMatch.ShouldAllowSubstitution() &&
+		!(arena.EventSettings.NexusEnabled && arena.CurrentMatch.ShouldAllowNexusSubstitution())
+
 	return &struct {
 		Match             *model.Match
 		AllowSubstitution bool
@@ -190,7 +194,7 @@ func (arena *Arena) GenerateMatchLoadMessage() any {
 		BreakDescription  string
 	}{
 		arena.CurrentMatch,
-		arena.CurrentMatch.ShouldAllowSubstitution(),
+		allowManualSubstitution,
 		isReplay,
 		teams,
 		rankings,

--- a/model/match.go
+++ b/model/match.go
@@ -7,10 +7,11 @@ package model
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena/game"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Team254/cheesy-arena/game"
 )
 
 //go:generate stringer -type=MatchType
@@ -147,6 +148,11 @@ func (match *Match) ShouldUpdateRankings() bool {
 // Returns true if the playoff match set should be updated as a result of the match.
 func (match *Match) ShouldUpdatePlayoffMatches() bool {
 	return match.Type == Playoff
+}
+
+// Returns true if the teams currently set in each station match the passed lineup.
+func (match *Match) IsLineupEqual(red1, red2, red3, blue1, blue2, blue3 int) bool {
+	return [6]int{match.Red1, match.Red2, match.Red3, match.Blue1, match.Blue2, match.Blue3} == [6]int{red1, red2, red3, blue1, blue2, blue3}
 }
 
 // Returns the enum equivalent of the given match type string.

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -495,8 +495,10 @@ UI for configuring event settings.
           <div class="tab-pane" id="automation" role="tabpanel">
             <fieldset class="mb-4">
               <legend>Nexus</legend>
-              <p>Automatically populates practice and playoff match lineups from Nexus. Uses the same event code as TBA;
-                configure it above if enabling.</p>
+              <p>Automatically populate practice and playoff match lineups from Nexus. Uses the same event code as TBA-
+                configure it on the publishing tab.</p>
+              <p>When enabled, Nexus is the source of truth for lineups and they can not
+                be overridden by the scorekeeper. To make changes, update the lineup in Nexus or disable this setting.</p>
               <div class="row mb-3">
                 <label class="col-lg-8 control-label" for="nexusEnabled">Enable pulling lineup from Nexus</label>
                 <div class="col-lg-1 checkbox">


### PR DESCRIPTION
This removes the requirement for scorekeepers to constantly monitor Nexus and manually reload the match when a late lineup change is submitted. This feature is behind the `NexusEnabled` event setting.

This also disables the ability to manually substitute teams, as any manual changes would just get overwritten. To substitute teams, the lineup should be updated in Nexus or the setting must be disabled.

During testing we mostly ran with a `periodicTaskPeriodSec` of 15- I think a period of ~15 seconds is ideal for improved responsiveness when a lineup is updated.

I tested this at 2025 Tidal Tumble, Capital City Classic, Beach Blitz and Madtown Throwdown. Feedback was positive and this change was one of several that allowed us to run without full-time scorekeepers.
