### PR TITLE
Automatic audience display transitions

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -1290,7 +1290,7 @@ func (arena *Arena) runPeriodicTasks() {
 }
 
 // Handles audience display automation from after score post to next match intro.
-func (arena *Arena) AutomateAudienceDisplay() {
+func (arena *Arena) AutomateAudienceDisplay(postedMatch *model.Match) {
 	// Show the score for 20 seconds before moving on.
 	time.Sleep(20 * time.Second)
 	if arena.AudienceDisplayMode != "score" {
@@ -1299,7 +1299,7 @@ func (arena *Arena) AutomateAudienceDisplay() {
 
 	if arena.CurrentMatch.Type == model.Playoff {
 		time.Sleep(10 * time.Second)
-		isFinals := strings.Contains(arena.CurrentMatch.LongName, "Final") || strings.Contains(arena.CurrentMatch.LongName, "Overtime")
+		isFinals := strings.Contains(postedMatch.LongName, "Final") || strings.Contains(postedMatch.LongName, "Overtime")
 		if !isFinals {
 			arena.SetAudienceDisplayMode("bracket")
 			time.Sleep(20 * time.Second)

--- a/field/arena.go
+++ b/field/arena.go
@@ -546,8 +546,7 @@ func (arena *Arena) AbortMatch() error {
 	}
 	arena.MatchState = PostMatch
 	arena.matchAborted = true
-	arena.AudienceDisplayMode = "blank"
-	arena.AudienceDisplayModeNotifier.Notify()
+	arena.SetAudienceDisplayMode("blank")
 	go arena.BlackmagicClient.StopRecording()
 	go arena.CompanionClient.SendEvent(partner.EventMatchAbort)
 	return nil
@@ -648,10 +647,8 @@ func (arena *Arena) Update() {
 		arena.MatchStartTime = time.Now()
 		arena.LastMatchTimeSec = -1
 		auto = true
-		arena.AudienceDisplayMode = "match"
-		arena.AudienceDisplayModeNotifier.Notify()
-		arena.AllianceStationDisplayMode = "match"
-		arena.AllianceStationDisplayModeNotifier.Notify()
+		arena.SetAudienceDisplayMode("match")
+		arena.SetAllianceStationDisplayMode("match")
 		go arena.BlackmagicClient.StartRecording()
 		go arena.CompanionClient.SendEvent(partner.EventMatchStart)
 		if game.MatchTiming.WarmupDurationSec > 0 {
@@ -713,8 +710,7 @@ func (arena *Arena) Update() {
 			go func() {
 				// Leave the scores on the screen briefly at the end of the match.
 				time.Sleep(time.Second * matchEndScoreDwellSec)
-				arena.AudienceDisplayMode = "blank"
-				arena.AudienceDisplayModeNotifier.Notify()
+				arena.SetAudienceDisplayMode("blank")
 			}()
 			go func() {
 				// Configure the network in advance for the next match after a delay.
@@ -728,10 +724,8 @@ func (arena *Arena) Update() {
 			go func() {
 				// Leave the timer on the screen briefly at the end of the timeout period.
 				time.Sleep(time.Second * matchEndScoreDwellSec)
-				arena.AudienceDisplayMode = "blank"
-				arena.AudienceDisplayModeNotifier.Notify()
-				arena.AllianceStationDisplayMode = "logo"
-				arena.AllianceStationDisplayModeNotifier.Notify()
+				arena.SetAudienceDisplayMode("intro")
+				arena.SetAllianceStationDisplayMode("match")
 			}()
 		}
 	case PostTimeout:
@@ -1293,6 +1287,47 @@ func (arena *Arena) runPeriodicTasks() {
 	arena.updateEarlyLateMessage()
 	arena.purgeDisconnectedDisplays()
 	arena.checkForUpdatedNexusLineup()
+}
+
+// Handles audience display automation from after score post to next match intro.
+func (arena *Arena) AutomateAudienceDisplay() {
+	// Show the score for 20 seconds before moving on.
+	time.Sleep(20 * time.Second)
+	if arena.AudienceDisplayMode != "score" {
+		return
+	}
+
+	if arena.CurrentMatch.Type == model.Playoff {
+		time.Sleep(10 * time.Second)
+		isFinals := strings.Contains(arena.CurrentMatch.LongName, "Final") || strings.Contains(arena.CurrentMatch.LongName, "Overtime")
+		if !isFinals {
+			arena.SetAudienceDisplayMode("bracket")
+			time.Sleep(20 * time.Second)
+			if arena.AudienceDisplayMode != "bracket" {
+				return
+			}
+		}
+	}
+
+	if arena.MatchState == TimeoutActive {
+		arena.SetAudienceDisplayMode("timeout")
+		arena.SetAllianceStationDisplayMode("timeout")
+		return
+	}
+
+	if arena.CurrentMatch.Type == model.Test {
+		// No next match loaded, show the score for longer and then go into awards mode.
+		time.Sleep(40 * time.Second)
+		if arena.AudienceDisplayMode != "score" {
+			return
+		}
+
+		arena.SetAudienceDisplayMode("logoLuma")
+		arena.SetAllianceStationDisplayMode("logo")
+		return
+	}
+
+	arena.SetAudienceDisplayMode("intro")
 }
 
 // trussLightWarningSequence generates the sequence of truss light states during the "sonar ping" warning sound. It

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -51,6 +51,7 @@ type EventSettings struct {
 	TbaEventCode                     string
 	TbaSecretId                      string
 	TbaSecret                        string
+	AutoAudienceDisplayEnabled       bool
 	NexusEnabled                     bool
 	NetworkSecurityEnabled           bool
 	ApAddress                        string

--- a/static/css/referee_panel.css
+++ b/static/css/referee_panel.css
@@ -215,6 +215,9 @@ h3 {
 #commitButton {
   background-color: #26c;
 }
+#commitButton.disabled {
+  background-color: #666;
+}
 
 #scoreSummary {
   width: 100%;

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -59,7 +59,7 @@ const signalReset = function () {
 };
 
 // Sends a websocket message to commit and post the match score, and load the next match.
-const commitResults = function () {
+const commitAndPost = function () {
   websocket.send("commitAndPost");
 };
 
@@ -102,7 +102,7 @@ const confirmCommit = function () {
     $("#confirmCommitNotReady").css("display", scoreIsReady ? "none" : "block");
     $("#confirmCommitResults").modal("show");
   } else {
-    commitResults();
+    commitAndPost();
   }
 };
 

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -58,9 +58,9 @@ const signalReset = function () {
   websocket.send("signalReset");
 };
 
-// Sends a websocket message to commit the match score and load the next match.
+// Sends a websocket message to commit and post the match score, and load the next match.
 const commitResults = function () {
-  websocket.send("commitResults");
+  websocket.send("commitAndPost");
 };
 
 // Sends a websocket message to discard the match score and load the next match.
@@ -73,13 +73,6 @@ const showOverlay = function () {
   $("input[name=audienceDisplay][value=intro]").prop("checked", true);
   setAudienceDisplay();
   $("#showOverlay").prop("disabled", true);
-}
-
-// Switches the audience display to the final score screen.
-const showFinalScore = function () {
-  $("input[name=audienceDisplay][value=score]").prop("checked", true);
-  setAudienceDisplay();
-  $("#showFinalScore").prop("disabled", true);
 }
 
 // Sends a websocket message to change what the audience display is showing.
@@ -203,7 +196,6 @@ const handleArenaStatus = function (data) {
     case "TELEOP_PERIOD":
       $("#showOverlay").prop("disabled", true);
       $("#introRadio").prop("disabled", true);
-      $("#showFinalScore").prop("disabled", true);
       $("#scoreRadio").prop("disabled", true);
       $("#startMatch").prop("disabled", true);
       $("#abortMatch").prop("disabled", false);
@@ -218,7 +210,6 @@ const handleArenaStatus = function (data) {
     case "POST_MATCH":
       $("#showOverlay").prop("disabled", true);
       $("#introRadio").prop("disabled", true);
-      $("#showFinalScore").prop("disabled", true);
       $("#scoreRadio").prop("disabled", true);
       $("#startMatch").prop("disabled", true);
       $("#abortMatch").prop("disabled", true);
@@ -233,7 +224,6 @@ const handleArenaStatus = function (data) {
     case "TIMEOUT_ACTIVE":
       $("#showOverlay").prop("disabled", true);
       $("#introRadio").prop("disabled", true);
-      $("#showFinalScore").prop("disabled", false);
       $("#scoreRadio").prop("disabled", false);
       $("#startMatch").prop("disabled", true);
       $("#abortMatch").prop("disabled", false);
@@ -248,7 +238,6 @@ const handleArenaStatus = function (data) {
     case "POST_TIMEOUT":
       $("#showOverlay").prop("disabled", false);
       $("#introRadio").prop("disabled", false);
-      $("#showFinalScore").prop("disabled", false);
       $("#scoreRadio").prop("disabled", false);
       $("#startMatch").prop("disabled", true);
       $("#abortMatch").prop("disabled", true);
@@ -323,7 +312,6 @@ const handleRealtimeScore = function (data) {
 const handleScorePosted = function (data) {
   let matchName = data.Match.LongName;
   if (matchName) {
-    $("#showFinalScore").prop("disabled", false);
     $("#scoreRadio").prop("disabled", false);
   } else {
     matchName = "None"

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -6,6 +6,7 @@
 var websocket;
 let redFoulsHashCode = 0;
 let blueFoulsHashCode = 0;
+let scoreIsReady = false;
 
 // Sends the foul to the server to add it to the list.
 const addFoul = function (alliance, isMajor) {
@@ -57,10 +58,20 @@ var signalReset = function () {
   websocket.send("signalReset");
 };
 
-// Signals the scorekeeper that foul entry is complete for this match.
-var commitMatch = function () {
-  websocket.send("commitMatch");
+// Shows confirmation modal if not all scores are ready, otherwise directly commits and posts.
+var confirmCommit = function () {
+  if(scoreIsReady) {
+    commitAndPost();
+    return;
+  }
+
+  $("#confirmCommit").modal('show');
 };
+
+// Commits the score and posts results to the audience.
+var commitAndPost = function () {
+  websocket.send("commitAndPost");
+}
 
 // Handles a websocket message to update the teams for the current match.
 var handleMatchLoad = function (data) {
@@ -73,17 +84,19 @@ var handleMatchLoad = function (data) {
   setTeamCard("blue", 2, data.Teams["B2"]);
   setTeamCard("blue", 3, data.Teams["B3"]);
 
-  $("#redScoreSummary .team-1").text(data.Teams["R1"].Id);
-  $("#redScoreSummary .team-2").text(data.Teams["R2"].Id);
-  $("#redScoreSummary .team-3").text(data.Teams["R3"].Id);
-  $("#blueScoreSummary .team-1").text(data.Teams["B1"].Id);
-  $("#blueScoreSummary .team-2").text(data.Teams["B2"].Id);
-  $("#blueScoreSummary .team-3").text(data.Teams["B3"].Id);
+  $("#redScoreSummary .team-1").text(data.Teams["R1"]?.Id);
+  $("#redScoreSummary .team-2").text(data.Teams["R2"]?.Id);
+  $("#redScoreSummary .team-3").text(data.Teams["R3"]?.Id);
+  $("#blueScoreSummary .team-1").text(data.Teams["B1"]?.Id);
+  $("#blueScoreSummary .team-2").text(data.Teams["B2"]?.Id);
+  $("#blueScoreSummary .team-3").text(data.Teams["B3"]?.Id);
 };
 
 // Handles a websocket message to update the match status.
 const handleMatchTime = function (data) {
-  $(".control-button").attr("data-enabled", matchStates[data.MatchState] === "POST_MATCH");
+  const enabled = matchStates[data.MatchState] === "POST_MATCH";
+  $(".control-button").attr("data-enabled", enabled);
+  $(".control-button").prop("disabled", !enabled);
 };
 
 const endgameStatusNames = [
@@ -155,6 +168,18 @@ const handleScoringStatus = function (data) {
   updateScoreStatus(data, "red_far", "#redFarScoreStatus", "Red Far");
   updateScoreStatus(data, "blue_near", "#blueNearScoreStatus", "Blue Near");
   updateScoreStatus(data, "blue_far", "#blueFarScoreStatus", "Blue Far");
+
+  scoreIsReady = Object.values(data.PositionStatuses)
+      .map(status => status.Ready)
+      .every(ready => ready);
+
+  // Make the button visually distinct if not all refs have committed.
+  // HR can still press the button with confirm model.
+  if(scoreIsReady) {
+    $("#commitButton").removeClass('disabled');
+  } else {
+    $("#commitButton").addClass('disabled');
+  }
 }
 
 // Helper function to update a badge that shows scoring panel commit status.

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -94,9 +94,7 @@ var handleMatchLoad = function (data) {
 
 // Handles a websocket message to update the match status.
 const handleMatchTime = function (data) {
-  const enabled = matchStates[data.MatchState] === "POST_MATCH";
-  $(".control-button").attr("data-enabled", enabled);
-  $(".control-button").prop("disabled", !enabled);
+  $(".control-button").attr("data-enabled", matchStates[data.MatchState] === "POST_MATCH");
 };
 
 const endgameStatusNames = [

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -167,9 +167,7 @@ const handleScoringStatus = function (data) {
   updateScoreStatus(data, "blue_near", "#blueNearScoreStatus", "Blue Near");
   updateScoreStatus(data, "blue_far", "#blueFarScoreStatus", "Blue Far");
 
-  scoreIsReady = Object.values(data.PositionStatuses)
-      .map(status => status.Ready)
-      .every(ready => ready);
+  scoreIsReady = Object.values(data.PositionStatuses).every(status => status.Ready);
 
   // Make the button visually distinct if not all refs have committed.
   // HR can still press the button with confirm model.

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -84,12 +84,12 @@ var handleMatchLoad = function (data) {
   setTeamCard("blue", 2, data.Teams["B2"]);
   setTeamCard("blue", 3, data.Teams["B3"]);
 
-  $("#redScoreSummary .team-1").text(data.Teams["R1"]?.Id);
-  $("#redScoreSummary .team-2").text(data.Teams["R2"]?.Id);
-  $("#redScoreSummary .team-3").text(data.Teams["R3"]?.Id);
-  $("#blueScoreSummary .team-1").text(data.Teams["B1"]?.Id);
-  $("#blueScoreSummary .team-2").text(data.Teams["B2"]?.Id);
-  $("#blueScoreSummary .team-3").text(data.Teams["B3"]?.Id);
+  $("#redScoreSummary .team-1").text(data.Teams["R1"]?.Id || '');
+  $("#redScoreSummary .team-2").text(data.Teams["R2"]?.Id || '');
+  $("#redScoreSummary .team-3").text(data.Teams["R3"]?.Id || '');
+  $("#blueScoreSummary .team-1").text(data.Teams["B1"]?.Id || '');
+  $("#blueScoreSummary .team-2").text(data.Teams["B2"]?.Id || '');
+  $("#blueScoreSummary .team-3").text(data.Teams["B3"]?.Id || '');
 };
 
 // Handles a websocket message to update the match status.

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -209,8 +209,8 @@ UI for controlling match play and viewing team connection and field status.
       <div class="modal-footer">
         <form class="form-horizontal" action="/setup/teams/clear" method="POST">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-danger" onclick="commitResults();" data-bs-dismiss="modal">
-            Commit Results
+          <button type="button" class="btn btn-danger" onclick="commitAndPost();" data-bs-dismiss="modal">
+            Commit &amp; post
           </button>
         </form>
       </div>

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -57,11 +57,7 @@ UI for controlling match play and viewing team connection and field status.
       </button>
       <button type="button" id="commitResults" class="btn btn-primary btn-match-play ms-1"
         onclick="confirmCommit();" disabled>
-        Commit Results
-      </button>
-      <button type="button" id="showFinalScore" class="btn btn-info btn-match-play ms-1"
-        onclick="showFinalScore();" disabled>
-        Show Final Score
+        Commit &amp; Post
       </button>
     </div>
     <div class="row justify-content-center mt-1">

--- a/templates/referee_panel.html
+++ b/templates/referee_panel.html
@@ -46,7 +46,28 @@ UI for entering and tracking fouls and red/yellow cards.
 <div id="controlButtons" class="headRef-dependent">
   <div class="control-button" id="volunteerButton" onclick="signalVolunteers();">Signal Count</div>
   <div class="control-button" id="resetButton" onclick="signalReset();">Signal Reset</div>
-  <div class="control-button" id="commitButton" onclick="commitMatch();">Commit Match</div>
+  <div class="control-button" id="commitButton" onclick="confirmCommit();">Commit & Post</div>
+</div>
+<div id="confirmCommit" class="modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="confirmDisableTitle">Scores not committed</h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to commit & post without all scoring tablets having committed?
+      </div>
+      <div class="modal-footer">
+        <form class="form-horizontal">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary ms-2" onclick="commitAndPost();" data-bs-dismiss="modal">
+            Commit & post
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 {{end}}
 {{define "head"}}

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -494,6 +494,16 @@ UI for configuring event settings.
           </div>
           <div class="tab-pane" id="automation" role="tabpanel">
             <fieldset class="mb-4">
+              <legend>Audience display</legend>
+              <p>Automatically advance audience display to the next match preview after scores are posted.</p>
+              <div class="row mb-3">
+                <label class="col-lg-8 control-label" for="autoAudienceDisplayEnabled">Enabled automated audience display</label>
+                <div class="col-lg-1 checkbox">
+                  <input type="checkbox" name="autoAudienceDisplayEnabled" {{if .AutoAudienceDisplayEnabled}} checked{{end}}>
+                </div>
+              </div>
+            </fieldset>
+            <fieldset class="mb-4">
               <legend>Nexus</legend>
               <p>Automatically populate practice and playoff match lineups from Nexus. Uses the same event code as TBA-
                 configure it on the publishing tab.</p>

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -358,6 +358,9 @@ func (web *Web) commitPostAndLoadNextMatch() error {
 	}
 
 	web.arena.SetAudienceDisplayMode("score")
+	if web.arena.EventSettings.AutoAudienceDisplayEnabled {
+		go web.arena.AutomateAudienceDisplay()
+	}
 
 	err = web.arena.ResetMatch()
 	if err != nil {

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -287,22 +287,8 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 			web.arena.SignalVolunteers()
 		case "signalReset":
 			web.arena.SignalReset()
-		case "commitResults":
-			if web.arena.MatchState != field.PostMatch {
-				ws.WriteError("cannot commit match while it is in progress")
-				continue
-			}
-			err = web.commitCurrentMatchScore()
-			if err != nil {
-				ws.WriteError(err.Error())
-				continue
-			}
-			err = web.arena.ResetMatch()
-			if err != nil {
-				ws.WriteError(err.Error())
-				continue
-			}
-			err = web.arena.LoadNextMatch(true)
+		case "commitAndPost":
+			err = web.commitPostAndLoadNextMatch()
 			if err != nil {
 				ws.WriteError(err.Error())
 				continue
@@ -359,6 +345,26 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 			ws.WriteError(fmt.Sprintf("Invalid message type '%s'.", messageType))
 		}
 	}
+}
+
+func (web *Web) commitPostAndLoadNextMatch() error {
+	if web.arena.MatchState != field.PostMatch {
+		return fmt.Errorf("Cannot commit match while it is in progress.")
+	}
+
+	err := web.commitCurrentMatchScore()
+	if err != nil {
+		return err
+	}
+
+	web.arena.SetAudienceDisplayMode("score")
+
+	err = web.arena.ResetMatch()
+	if err != nil {
+		return err
+	}
+
+	return web.arena.LoadNextMatch(true)
 }
 
 // Saves the given match and result to the database, supplanting any previous result for the match.

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -359,7 +359,7 @@ func (web *Web) commitPostAndLoadNextMatch() error {
 
 	web.arena.SetAudienceDisplayMode("score")
 	if web.arena.EventSettings.AutoAudienceDisplayEnabled {
-		go web.arena.AutomateAudienceDisplay()
+		go web.arena.AutomateAudienceDisplay(web.arena.CurrentMatch)
 	}
 
 	err = web.arena.ResetMatch()

--- a/web/match_play_test.go
+++ b/web/match_play_test.go
@@ -5,6 +5,10 @@ package web
 
 import (
 	"bytes"
+	"log"
+	"testing"
+	"time"
+
 	"github.com/Team254/cheesy-arena/field"
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/model"
@@ -13,9 +17,6 @@ import (
 	gorillawebsocket "github.com/gorilla/websocket"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
-	"log"
-	"testing"
-	"time"
 )
 
 func TestMatchPlay(t *testing.T) {
@@ -314,6 +315,7 @@ func TestMatchPlayWebsocketCommands(t *testing.T) {
 	assert.Equal(t, false, web.arena.AllianceStations["R3"].Bypass)
 
 	// Go through match flow.
+	web.arena.AudienceDisplayMode = "intro"
 	ws.Write("abortMatch", nil)
 	assert.Contains(t, readWebsocketError(t, ws), "cannot abort match")
 	ws.Write("startMatch", nil)
@@ -467,6 +469,8 @@ func TestMatchPlayWebsocketNotifications(t *testing.T) {
 	// Should get a few status updates right after connection.
 	readWebsocketMultiple(t, ws, 10)
 
+	web.arena.AudienceDisplayMode = "intro"
+	web.arena.AllianceStationDisplayMode = "blank"
 	web.arena.AllianceStations["R1"].Bypass = true
 	web.arena.AllianceStations["R2"].Bypass = true
 	web.arena.AllianceStations["R3"].Bypass = true

--- a/web/match_play_test.go
+++ b/web/match_play_test.go
@@ -327,8 +327,8 @@ func TestMatchPlayWebsocketCommands(t *testing.T) {
 	ws.Write("startMatch", nil)
 	readWebsocketType(t, ws, "eventStatus")
 	assert.Equal(t, field.StartMatch, web.arena.MatchState)
-	ws.Write("commitResults", nil)
-	assert.Contains(t, readWebsocketError(t, ws), "cannot commit match while it is in progress")
+	ws.Write("commitAndPost", nil)
+	assert.Contains(t, readWebsocketError(t, ws), "Cannot commit match while it is in progress.")
 	ws.Write("discardResults", nil)
 	assert.Contains(t, readWebsocketError(t, ws), "cannot reset match while it is in progress")
 	ws.Write("abortMatch", nil)
@@ -336,8 +336,8 @@ func TestMatchPlayWebsocketCommands(t *testing.T) {
 	assert.Equal(t, field.PostMatch, web.arena.MatchState)
 	web.arena.RedRealtimeScore.CurrentScore.BargeAlgae = 6
 	web.arena.BlueRealtimeScore.CurrentScore.LeaveStatuses = [3]bool{true, false, true}
-	ws.Write("commitResults", nil)
-	readWebsocketMultiple(t, ws, 5) // scorePosted, matchLoad, realtimeScore, allianceStationDisplayMode, scoringStatus
+	ws.Write("commitAndPost", nil)
+	readWebsocketMultiple(t, ws, 6) // scorePosted, matchLoad, realtimeScore, allianceStationDisplayMode, scoringStatus, audienceDisplayMode
 	assert.Equal(t, 6, web.arena.SavedMatchResult.RedScore.BargeAlgae)
 	assert.Equal(t, [3]bool{true, false, true}, web.arena.SavedMatchResult.BlueScore.LeaveStatuses)
 	assert.Equal(t, field.PreMatch, web.arena.MatchState)

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -209,23 +209,11 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			web.arena.BlueRealtimeScore.FoulsCommitted = true
 			web.arena.ScoringStatusNotifier.Notify()
 
-			err = web.commitCurrentMatchScore()
+			err = web.commitPostAndLoadNextMatch()
 			if err != nil {
 				ws.WriteError(err.Error())
 				continue
 			}
-			err = web.arena.ResetMatch()
-			if err != nil {
-				ws.WriteError(err.Error())
-				continue
-			}
-			err = web.arena.LoadNextMatch(true)
-			if err != nil {
-				ws.WriteError(err.Error())
-				continue
-			}
-
-			web.arena.SetAudienceDisplayMode("score")
 		default:
 			ws.WriteError(fmt.Sprintf("Invalid message type '%s'.", messageType))
 		}

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -7,15 +7,16 @@ package web
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+
 	"github.com/Team254/cheesy-arena/field"
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/Team254/cheesy-arena/websocket"
 	"github.com/mitchellh/mapstructure"
-	"io"
-	"log"
-	"net/http"
-	"strconv"
 )
 
 // Renders the referee interface for assigning fouls.
@@ -199,18 +200,32 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			web.arena.SignalVolunteers()
 		case "signalReset":
 			web.arena.SignalReset()
-		case "commitMatch":
+		case "commitAndPost":
 			if web.arena.MatchState != field.PostMatch {
 				// Don't allow committing the fouls until the match is over.
 				continue
 			}
 			web.arena.RedRealtimeScore.FoulsCommitted = true
 			web.arena.BlueRealtimeScore.FoulsCommitted = true
-			web.arena.FieldVolunteers = false
-			web.arena.FieldReset = true
-			web.arena.AllianceStationDisplayMode = "fieldReset"
-			web.arena.AllianceStationDisplayModeNotifier.Notify()
 			web.arena.ScoringStatusNotifier.Notify()
+
+			err = web.commitCurrentMatchScore()
+			if err != nil {
+				ws.WriteError(err.Error())
+				continue
+			}
+			err = web.arena.ResetMatch()
+			if err != nil {
+				ws.WriteError(err.Error())
+				continue
+			}
+			err = web.arena.LoadNextMatch(true)
+			if err != nil {
+				ws.WriteError(err.Error())
+				continue
+			}
+
+			web.arena.SetAudienceDisplayMode("score")
 		default:
 			ws.WriteError(fmt.Sprintf("Invalid message type '%s'.", messageType))
 		}

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -226,6 +226,10 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			}
 
 			web.arena.SetAudienceDisplayMode("score")
+
+			if web.arena.EventSettings.AutoAudienceDisplayEnabled {
+				go web.arena.AutomateAudienceDisplay()
+			}
 		default:
 			ws.WriteError(fmt.Sprintf("Invalid message type '%s'.", messageType))
 		}

--- a/web/referee_panel_test.go
+++ b/web/referee_panel_test.go
@@ -4,13 +4,14 @@
 package web
 
 import (
+	"testing"
+	"time"
+
 	"github.com/Team254/cheesy-arena/field"
 	"github.com/Team254/cheesy-arena/model"
 	"github.com/Team254/cheesy-arena/websocket"
 	gorillawebsocket "github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestRefereePanel(t *testing.T) {
@@ -157,7 +158,8 @@ func TestRefereePanelWebsocket(t *testing.T) {
 		assert.Equal(t, "yellow", web.arena.BlueRealtimeScore.Cards["1681"])
 	}
 
-	// Test field reset and match committing.
+	// Test field reset.
+	web.arena.CurrentMatch.Type = model.Test
 	web.arena.MatchState = field.PostMatch
 	ws.Write("signalReset", nil)
 	time.Sleep(time.Millisecond * 10)
@@ -165,13 +167,13 @@ func TestRefereePanelWebsocket(t *testing.T) {
 	assert.False(t, web.arena.RedRealtimeScore.FoulsCommitted)
 	assert.False(t, web.arena.BlueRealtimeScore.FoulsCommitted)
 	web.arena.AllianceStationDisplayMode = "logo"
-	ws.Write("commitMatch", nil)
-	readWebsocketType(t, ws, "scoringStatus")
-	assert.Equal(t, "fieldReset", web.arena.AllianceStationDisplayMode)
-	assert.True(t, web.arena.RedRealtimeScore.FoulsCommitted)
-	assert.True(t, web.arena.BlueRealtimeScore.FoulsCommitted)
 
-	// Should refresh the page when the next match is loaded.
-	web.arena.MatchLoadNotifier.Notify()
-	readWebsocketType(t, ws, "matchLoad")
+	// Test commit, post, and load next match.
+	ws.Write("commitAndPost", nil)
+	readWebsocketType(t, ws, "scoringStatus")
+	messages := readWebsocketMultiple(t, ws, 3)
+	assert.NotNil(t, messages["realtimeScore"])
+	assert.NotNil(t, messages["scoringStatus"])
+	assert.NotNil(t, messages["matchLoad"])
+	assert.Equal(t, "score", web.arena.AudienceDisplayMode)
 }

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -7,8 +7,6 @@ package web
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena/field"
-	"github.com/Team254/cheesy-arena/model"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Team254/cheesy-arena/field"
+	"github.com/Team254/cheesy-arena/model"
 )
 
 // Shows the event settings editing page.
@@ -84,6 +85,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.TbaEventCode = r.PostFormValue("tbaEventCode")
 	eventSettings.TbaSecretId = r.PostFormValue("tbaSecretId")
 	eventSettings.TbaSecret = r.PostFormValue("tbaSecret")
+	eventSettings.AutoAudienceDisplayEnabled = r.PostFormValue("autoAudienceDisplayEnabled") == "on"
 	eventSettings.NexusEnabled = r.PostFormValue("nexusEnabled") == "on"
 	eventSettings.NetworkSecurityEnabled = r.PostFormValue("networkSecurityEnabled") == "on"
 	eventSettings.ApAddress = r.PostFormValue("apAddress")


### PR DESCRIPTION
When the setting is enabled, the audience display will automatically transition after match scores are posted to reduce the manual button pressing the scorekeeper has to do.

Transition flows:
- Practice/Quals: Final scores (20 seconds) -> Match intro
- Finals: Final scores (30 seconds) -> Timeout
- Playoffs (non-finals): Final scores (30 seconds) -> Bracket (20 seconds) -> Match intro/Timeout
- Last match: Final scores (60 seconds) -> Logo

This was tested at 4 2025 offseasons, received positive feedback, and was one of the changes that allowed us to run without a  scorekeeper.

All changes
- Add AutoAudienceDisplayEnabled setting
- Implement automated audience display transitions after scores are posted from either match play or the head ref panel
- Update transition after timeout ends to set audience display to Match intro instead of blank

(forked from https://github.com/NexusRoboticsFoundation/cheesy-arena/tree/ref-post)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional automated audience display progression after scores are posted (toggle in event settings).
  * Commit flow now posts scores and advances match state in one action.

* **UI Changes**
  * “Commit Results” renamed to “Commit & Post”.
  * Commit button disabled style updated for clearer muted appearance.

* **Quality of Life**
  * Scoring readiness tracked; confirmation modal appears if committing when not all tablets are ready.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team254/cheesy-arena/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->