### PR TITLE
Allow head refs to disable robots from their panel

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -1312,6 +1312,15 @@ func (arena *Arena) getHubLightStates(currentTime time.Time) (bool, bool) {
 	}
 }
 
+func (arena *Arena) ToggleBypass(station string) (error) {
+	if _, ok := arena.AllianceStations[station]; !ok {
+		return fmt.Errorf("Invalid alliance station '%s'.", station)
+	}
+	arena.AllianceStations[station].Bypass = !arena.AllianceStations[station].Bypass
+	arena.ArenaStatusNotifier.Notify()
+	return nil
+}
+
 func (arena *Arena) handleTeamStop(station string, eStopState, aStopState bool) {
 	allianceStation := arena.AllianceStations[station]
 	if eStopState {

--- a/field/arena.go
+++ b/field/arena.go
@@ -1312,7 +1312,7 @@ func (arena *Arena) getHubLightStates(currentTime time.Time) (bool, bool) {
 	}
 }
 
-func (arena *Arena) ToggleBypass(station string) (error) {
+func (arena *Arena) ToggleBypass(station string) error {
 	if _, ok := arena.AllianceStations[station]; !ok {
 		return fmt.Errorf("Invalid alliance station '%s'.", station)
 	}

--- a/static/css/referee_panel.css
+++ b/static/css/referee_panel.css
@@ -57,6 +57,12 @@ h3 {
 #blueCards {
   background-color: #223;
 }
+.team-card.enabled-status {
+  background-color: #198754;
+}
+.team-card.bypassed-status {
+  background-color: #dc3545;
+}
 .team-card {
   margin: 0.5vw 0;
   width: 10vw;

--- a/static/css/referee_panel.css
+++ b/static/css/referee_panel.css
@@ -57,9 +57,6 @@ h3 {
 #blueCards {
   background-color: #223;
 }
-.team-card.enabled-status {
-  background-color: #198754;
-}
 .team-card.bypassed-status {
   background-color: #dc3545;
 }

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -7,6 +7,7 @@ var websocket;
 let redFoulsHashCode = 0;
 let blueFoulsHashCode = 0;
 let scoreIsReady = false;
+let isPostMatch = false;
 
 // Sends the foul to the server to add it to the list.
 const addFoul = function (alliance, isMajor) {
@@ -35,22 +36,44 @@ var deleteFoul = function (alliance, index) {
 
 // Cycles through the card options for the selected team.
 var cycleCard = function (cardButton) {
-  const currentCard = $(cardButton).attr("data-card");
-  const hasOldYellowCard = $(cardButton).attr("data-old-yellow-card") === "true";
-  let newCard = "";
-  if (currentCard === "" && hasOldYellowCard) {
-    newCard = "red";
-  } else if (currentCard === "") {
-    newCard = "yellow";
-  } else if (currentCard === "yellow") {
-    newCard = "red";
+  if(isPostMatch) {
+    // Cycle card.
+    const currentCard = $(cardButton).attr("data-card");
+    const hasOldYellowCard = $(cardButton).attr("data-old-yellow-card") === "true";
+    let newCard = "";
+    if (currentCard === "" && hasOldYellowCard) {
+      newCard = "red";
+    } else if (currentCard === "") {
+      newCard = "yellow";
+    } else if (currentCard === "yellow") {
+      newCard = "red";
+    }
+    websocket.send(
+      "card",
+      {Alliance: $(cardButton).attr("data-alliance"), TeamId: parseInt($(cardButton).attr("data-team")), Card: newCard}
+    );
+    $(cardButton).attr("data-card", newCard);
+    return;
   }
-  websocket.send(
-    "card",
-    {Alliance: $(cardButton).attr("data-alliance"), TeamId: parseInt($(cardButton).attr("data-team")), Card: newCard}
-  );
-  $(cardButton).attr("data-card", newCard);
+
+  // Toggle bypass.
+  const isDisabled = $(cardButton).hasClass("bypassed-status");
+  const team = $(cardButton).attr("data-team");
+  $("#confirmBypassTitle").text(`${isDisabled ? "Enable" : "Disable"} ${team}?`);
+  $("#confirmBypassAction").text(isDisabled ? "Enable" : "Disable")
+  $("#confirmBypass").attr("data-station", $(cardButton).attr("data-station")?.toUpperCase());
+
+  if(team === "0") {
+    toggleBypass();
+  } else {
+    $("#confirmBypass").modal("show");
+  }
 };
+
+const toggleBypass = function() {
+  const station = $("#confirmBypass").attr("data-station");
+  websocket.send("toggleBypass", station);
+}
 
 // Sends a websocket message to signal to the volunteers that they may enter the field.
 var signalVolunteers = function () {
@@ -98,7 +121,15 @@ var handleMatchLoad = function (data) {
 
 // Handles a websocket message to update the match status.
 const handleMatchTime = function (data) {
-  $(".control-button").attr("data-enabled", matchStates[data.MatchState] === "POST_MATCH");
+  isPostMatch = matchStates[data.MatchState] === "POST_MATCH";
+  $(".control-button").attr("data-enabled", isPostMatch);
+
+  let title = "Red/Yellow Cards";
+  if(!isPostMatch) {
+    title = matchStates[data.MatchState] === "PRE_MATCH" ? "Bypass" : "Disable";
+  }
+
+  $("#teamTitle").text(title)
 };
 
 const towerStatusNames = [
@@ -166,6 +197,21 @@ const handleScoringStatus = function (data) {
   }
 }
 
+const handleArenaStatus = function (data) {
+  setTeamBypassedStatus("red1", data.AllianceStations["R1"]?.Bypass);
+  setTeamBypassedStatus("red2", data.AllianceStations["R2"]?.Bypass);
+  setTeamBypassedStatus("red3", data.AllianceStations["R3"]?.Bypass);
+  setTeamBypassedStatus("blue1", data.AllianceStations["B1"]?.Bypass);
+  setTeamBypassedStatus("blue2", data.AllianceStations["B2"]?.Bypass);
+  setTeamBypassedStatus("blue3", data.AllianceStations["B3"]?.Bypass);
+};
+
+const setTeamBypassedStatus = function (station, bypassed) {
+  const cardButton = $(`#${station}Card`);
+  cardButton.toggleClass("enabled-status", !bypassed && !isPostMatch);
+  cardButton.toggleClass("bypassed-status", bypassed && !isPostMatch);
+}
+
 // Helper function to update a badge that shows scoring panel commit status.
 const updateScoreStatus = function (data, position, element, displayName) {
   const status = data.PositionStatuses[position];
@@ -176,7 +222,7 @@ const updateScoreStatus = function (data, position, element, displayName) {
 
 // Populates the red/yellow card button for a given team.
 const setTeamCard = function (alliance, position, team) {
-  const cardButton = $(`#${alliance}Team${position}Card`);
+  const cardButton = $(`#${alliance}${position}Card`);
   if (team === null) {
     cardButton.text(0);
     cardButton.attr("data-team", 0)
@@ -217,6 +263,9 @@ $(function () {
     },
     scoringStatus: function (event) {
       handleScoringStatus(event.data);
+    },
+    arenaStatus: function (event) {
+      handleArenaStatus(event.data);
     },
   });
 });

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -223,7 +223,7 @@ const updateScoreStatus = function (data, position, element, displayName) {
 const setTeamCard = function (alliance, position, team) {
   const cardButton = $(`#${alliance}${position}Card`);
   if (team === null) {
-    cardButton.text(0);
+    cardButton.text("-");
     cardButton.attr("data-team", 0)
     cardButton.attr("data-old-yellow-card", "");
   } else {

--- a/static/js/referee_panel.js
+++ b/static/js/referee_panel.js
@@ -208,7 +208,6 @@ const handleArenaStatus = function (data) {
 
 const setTeamBypassedStatus = function (station, bypassed) {
   const cardButton = $(`#${station}Card`);
-  cardButton.toggleClass("enabled-status", !bypassed && !isPostMatch);
   cardButton.toggleClass("bypassed-status", bypassed && !isPostMatch);
 }
 

--- a/templates/referee_panel.html
+++ b/templates/referee_panel.html
@@ -9,7 +9,7 @@ UI for entering and tracking fouls and red/yellow cards.
 <div id="matchName"></div>
 <div id="refereePanel">
   <div id="cards" class="headRef-dependent">
-    <h3>Red/Yellow Cards</h3>
+    <h3 id="teamTitle">Red/Yellow Cards</h3>
     <div class="alliance-cards" id="redCards">
       {{range $i := seq 3}}
       {{template "teamCard" dict "alliance" "red" "position" $i}}
@@ -50,7 +50,7 @@ UI for entering and tracking fouls and red/yellow cards.
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title" id="confirmDisableTitle">Scores not committed</h4>
+        <h4 class="modal-title">Scores not committed</h4>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
@@ -61,6 +61,24 @@ UI for entering and tracking fouls and red/yellow cards.
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
           <button type="button" class="btn btn-primary ms-2" onclick="commitAndPost();" data-bs-dismiss="modal">
             Commit & Post
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="confirmBypass" class="modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="confirmBypassTitle">Disable?</h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-footer">
+        <form class="form-horizontal">
+          <button type="button" class="btn btn-lg btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-lg btn-danger ms-2" onclick="toggleBypass();" data-bs-dismiss="modal" id="confirmBypassAction">
+            Disable
           </button>
         </form>
       </div>
@@ -78,7 +96,7 @@ UI for entering and tracking fouls and red/yellow cards.
 <script src="/static/js/referee_panel.js"></script>
 {{end}}
 {{define "teamCard"}}
-<div class="team-card" id="{{.alliance}}Team{{.position}}Card" data-alliance="{{.alliance}}" onclick="cycleCard(this);">
+<div class="team-card" id="{{.alliance}}{{.position}}Card" data-alliance="{{.alliance}}" data-station="{{slice .alliance 0 1}}{{.position}}" onclick="cycleCard(this);">
 </div>
 {{end}}
 {{define "scoreSummary"}}

--- a/web/match_play.go
+++ b/web/match_play.go
@@ -255,13 +255,10 @@ func (web *Web) matchPlayWebsocketHandler(w http.ResponseWriter, r *http.Request
 				writeWebsocketError(ws, fmt.Sprintf("Failed to parse '%s' message.", messageType))
 				continue
 			}
-			if _, ok := web.arena.AllianceStations[station]; !ok {
-				writeWebsocketError(ws, fmt.Sprintf("Invalid alliance station '%s'.", station))
+			err = web.arena.ToggleBypass(station)
+			if err != nil {
+				writeWebsocketError(ws, err.Error())
 				continue
-			}
-			web.arena.AllianceStations[station].Bypass = !web.arena.AllianceStations[station].Bypass
-			if err = ws.WriteNotifier(web.arena.ArenaStatusNotifier); err != nil {
-				log.Println(err)
 			}
 		case "startMatch":
 			args := struct {

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -87,6 +87,7 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 		web.arena.RealtimeScoreNotifier,
 		web.arena.ScoringStatusNotifier,
 		web.arena.ReloadDisplaysNotifier,
+		web.arena.ArenaStatusNotifier,
 	)
 
 	// Loop, waiting for commands and responding to them, until the client closes the connection.
@@ -196,6 +197,17 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 				cards[strconv.Itoa(args.TeamId)] = args.Card
 			}
 			web.arena.RealtimeScoreNotifier.Notify()
+		case "toggleBypass":
+			station, ok := data.(string)
+			if !ok {
+				ws.WriteError(fmt.Sprintf("Failed to parse '%s' message.", messageType))
+				continue
+			}
+			err = web.arena.ToggleBypass(station)
+			if err != nil {
+				writeWebsocketError(ws, err.Error())
+				continue
+			}
 		case "signalVolunteers":
 			web.arena.SignalVolunteers()
 		case "signalReset":

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -200,7 +200,7 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 		case "toggleBypass":
 			station, ok := data.(string)
 			if !ok {
-				ws.WriteError(fmt.Sprintf("Failed to parse '%s' message.", messageType))
+				writeWebsocketError(ws, fmt.Sprintf("Failed to parse '%s' message.", messageType))
 				continue
 			}
 			err = web.arena.ToggleBypass(station)

--- a/web/referee_panel_test.go
+++ b/web/referee_panel_test.go
@@ -52,6 +52,7 @@ func TestRefereePanelWebsocket(t *testing.T) {
 	ws.Write("addFoul", addFoulData)
 	addFoulData.Alliance = "blue"
 	ws.Write("addFoul", addFoulData)
+	readWebsocketType(t, ws, "arenaStatus")
 	readWebsocketType(t, ws, "realtimeScore")
 	readWebsocketType(t, ws, "realtimeScore")
 	readWebsocketType(t, ws, "realtimeScore")


### PR DESCRIPTION
Repurposes the yellow/red card buttons on the head ref panel to toggle the bypass status of robots when not in post-match. Behavior of carding is unchanged when in post-match state. This was tested at 4 offseasons in 2025 and was added to official FMS before the 2026 season.

<img width="1283" height="726" alt="localhost_8080_panels_referee" src="https://github.com/user-attachments/assets/7684d258-98be-4e6a-b0d7-8afdf23dd310" />

<img width="1283" height="726" alt="localhost_8080_panels_referee (1)" src="https://github.com/user-attachments/assets/9d01cf6a-c0c5-4e20-9799-e85a39e318e7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added station-level “Disable/Bypass” controls with a confirmation dialog on the referee panel.
  * Referee panel now reacts to post-match mode by cycling card states and sending card updates over the websocket.
  * Added live updates for station bypass status across the panel.

* **Bug Fixes**
  * Improved websocket handling for bypass toggles with proper error reporting.

* **Style**
  * Bypassed team cards now display a red background to make the status clear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->