### PR TITLE
Arean LED change Notifier

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -105,6 +105,8 @@ type Arena struct {
 	NextFoulId                        int
 	DriverStationUdpSocket            *net.UDPConn
 	redWonAuto                        bool
+	lastRedLedMode  				  led.Mode
+	lastBlueLedMode 				  led.Mode
 }
 
 type AllianceStation struct {
@@ -401,6 +403,10 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
 	arena.Leds.SetMode(led.OffMode, led.OffMode)
+	currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()
@@ -1349,6 +1355,10 @@ func (arena *Arena) SignalVolunteers() {
 	arena.AllianceStationDisplayMode = "signalCount"
 	arena.AllianceStationDisplayModeNotifier.Notify()
 	arena.Leds.SetMode(led.PurpleMode, led.PurpleMode)
+	currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 }
 
 // Set the field lights and team signs to green, if not in a match.
@@ -1366,6 +1376,10 @@ func (arena *Arena) SignalReset() {
 	arena.AllianceStationDisplayMode = "fieldReset"
 	arena.AllianceStationDisplayModeNotifier.Notify()
 	arena.Leds.SetMode(led.GreenMode, led.GreenMode)
+	currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 }
 
 func (arena *Arena) handleSounds(matchTimeSec float64) {

--- a/field/arena_leds.go
+++ b/field/arena_leds.go
@@ -22,8 +22,16 @@ func (arena *Arena) updateHubLeds(currentTime time.Time) {
 	switch arena.MatchState {
 	case AutoPeriod:
 		arena.Leds.SetMode(led.RedStartupMode, led.BlueStartupMode)
+		currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 	case PausePeriod:
 		arena.Leds.SetMode(led.RedMode, led.BlueMode)
+		currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 	case TeleopPeriod:
 		arena.updateTeleopHubLeds(currentTime)
 	case PostMatch:
@@ -31,9 +39,17 @@ func (arena *Arena) updateHubLeds(currentTime time.Time) {
 			// Set the Hub LEDs to white at the end of the match, and then turn them off when the referees are supposed
 			// to assess tower climbs.
 			arena.Leds.SetMode(led.WhiteMode, led.WhiteMode)
+			currentRed, currentBlue := arena.Leds.GetModes()
+				if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+					arena.LedChangeNotifier.Notify()
+				}
 			go func() {
 				time.Sleep(hubLightScoringAssessmentSec * time.Second)
 				arena.Leds.SetMode(led.OffMode, led.OffMode)
+				currentRed, currentBlue := arena.Leds.GetModes()
+					if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+						arena.LedChangeNotifier.Notify()
+					}
 			}()
 		}
 	}
@@ -102,4 +118,8 @@ func (arena *Arena) updateTeleopHubLeds(currentTime time.Time) {
 		}
 	}
 	arena.Leds.SetMode(redMode, blueMode)
+	currentRed, currentBlue := arena.Leds.GetModes()
+		if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+			arena.LedChangeNotifier.Notify()
+		}
 }

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -30,6 +30,7 @@ type ArenaNotifiers struct {
 	ReloadDisplaysNotifier             *websocket.Notifier
 	ScorePostedNotifier                *websocket.Notifier
 	ScoringStatusNotifier              *websocket.Notifier
+	LedChangeNotifier 				   *websocket.Notifier
 }
 
 type MatchTimeMessage struct {
@@ -67,6 +68,7 @@ func (arena *Arena) configureNotifiers() {
 	arena.ReloadDisplaysNotifier = websocket.NewNotifier("reload", nil)
 	arena.ScorePostedNotifier = websocket.NewNotifier("scorePosted", arena.GenerateScorePostedMessage)
 	arena.ScoringStatusNotifier = websocket.NewNotifier("scoringStatus", arena.generateScoringStatusMessage)
+	arena.LedChangeNotifier = websocket.NewNotifier("setLedMode", arena.generateLedModeMessage)
 }
 
 func (arena *Arena) generateAllianceSelectionMessage() any {
@@ -377,6 +379,25 @@ func (arena *Arena) generateScoringStatusMessage() any {
 			"blue": getStatusForPosition("blue"),
 		},
 	}
+}
+
+func (arena *Arena) generateLedModeMessage() interface{} {
+    redMode, blueMode := arena.Leds.GetModes()
+
+	log.Printf("Generating LED mode message with RedMode=%d and BlueMode=%d", redMode, blueMode)
+
+    // Only notify if mode has actually changed
+    if redMode == arena.lastRedLedMode && blueMode == arena.lastBlueLedMode {
+       // return nil      // Return nil to suppress the notification
+    }
+
+    arena.lastRedLedMode  = redMode
+    arena.lastBlueLedMode = blueMode
+
+    return map[string]interface{}{
+        "RedMode":  redMode,
+        "BlueMode": blueMode,
+    }
 }
 
 // Constructs the data object for one alliance sent to the audience display for the realtime scoring overlay.

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -75,6 +75,12 @@ var handleArenaStatus = function (data) {
   updateCoilOverrideTooltips();
 };
 
+// Handles a websocket message to update the LED mode selection.
+var handLEDModeChange = function (data) {
+  $("input[name=redLedMode][value=" + data.RedMode + "]").prop("checked", true);
+  $("input[name=blueLedMode][value=" + data.BlueMode + "]").prop("checked", true);
+}
+
 $(function () {
   updateCoilOverrideTooltips();
 
@@ -95,6 +101,9 @@ $(function () {
     },
     arenaStatus: function (event) {
       handleArenaStatus(event.data);
+    },
+    setLedMode: function (event) {
+      handLEDModeChange(event.data);
     }
   });
 });

--- a/web/setup_field_testing.go
+++ b/web/setup_field_testing.go
@@ -76,7 +76,7 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 	defer closeWebsocket(ws)
 
 	// Subscribe the websocket to the notifiers whose messages will be passed on to the client, in a separate goroutine.
-	go ws.HandleNotifiers(web.arena.Plc.IoChangeNotifier(), web.arena.ArenaStatusNotifier)
+	go ws.HandleNotifiers(web.arena.Plc.IoChangeNotifier(), web.arena.ArenaStatusNotifier, web.arena.LedChangeNotifier)
 
 	// Loop, waiting for commands and responding to them, until the client closes the connection.
 	for {
@@ -149,6 +149,7 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 			}
 
 			web.arena.Leds.SetMode(args.RedMode, args.BlueMode)
+			web.arena.LedChangeNotifier.Notify()
 		default:
 			writeWebsocketError(ws, fmt.Sprintf("Invalid message type '%s'.", messageType))
 			continue


### PR DESCRIPTION
This is the solution I found for resolving issue #283 

There may be a less intrusive way to do this that fits better into the CA architecture. Also the /setup_field_testing_test now fails because there are multiple WS and not just the "plcIoChange" message. I have had this issue before in other areas I we have adjusted to fit our needs. I would like to see how you would resolve this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time LED mode change notifications to the field testing interface, ensuring LED status updates are properly synchronized across the system and displayed to users when LED states change during match operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->