### PR TITLE
Arean LED change Notifier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/field/arena.go
+++ b/field/arena.go
@@ -105,6 +105,8 @@ type Arena struct {
 	NextFoulId                        int
 	DriverStationUdpSocket            *net.UDPConn
 	redWonAuto                        bool
+	lastRedLedMode                    led.Mode
+	lastBlueLedMode                   led.Mode
 }
 
 type AllianceStation struct {
@@ -400,7 +402,7 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.Plc.ResetMatch()
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
-	arena.Leds.SetMode(led.OffMode, led.OffMode)
+	arena.SetLedMode(led.OffMode, led.OffMode)
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()
@@ -1348,7 +1350,7 @@ func (arena *Arena) SignalVolunteers() {
 	arena.FieldReset = false
 	arena.AllianceStationDisplayMode = "signalCount"
 	arena.AllianceStationDisplayModeNotifier.Notify()
-	arena.Leds.SetMode(led.PurpleMode, led.PurpleMode)
+	arena.SetLedMode(led.PurpleMode, led.PurpleMode)
 }
 
 // Set the field lights and team signs to green, if not in a match.
@@ -1365,7 +1367,7 @@ func (arena *Arena) SignalReset() {
 	arena.FieldReset = true
 	arena.AllianceStationDisplayMode = "fieldReset"
 	arena.AllianceStationDisplayModeNotifier.Notify()
-	arena.Leds.SetMode(led.GreenMode, led.GreenMode)
+	arena.SetLedMode(led.GreenMode, led.GreenMode)
 }
 
 func (arena *Arena) handleSounds(matchTimeSec float64) {

--- a/field/arena_leds.go
+++ b/field/arena_leds.go
@@ -17,23 +17,32 @@ const (
 	hubLightScoringAssessmentSec
 )
 
+// SetLedMode updates the Hub LED mode and notifies listeners if the published mode changed.
+func (arena *Arena) SetLedMode(redMode, blueMode led.Mode) {
+	arena.Leds.SetMode(redMode, blueMode)
+	currentRed, currentBlue := arena.Leds.GetModes()
+	if currentRed != arena.lastRedLedMode || currentBlue != arena.lastBlueLedMode {
+		arena.LedChangeNotifier.Notify()
+	}
+}
+
 // updateHubLeds updates Hub LEDs based on the current match state and active scoring shift.
 func (arena *Arena) updateHubLeds(currentTime time.Time) {
 	switch arena.MatchState {
 	case AutoPeriod:
-		arena.Leds.SetMode(led.RedStartupMode, led.BlueStartupMode)
+		arena.SetLedMode(led.RedStartupMode, led.BlueStartupMode)
 	case PausePeriod:
-		arena.Leds.SetMode(led.RedMode, led.BlueMode)
+		arena.SetLedMode(led.RedMode, led.BlueMode)
 	case TeleopPeriod:
 		arena.updateTeleopHubLeds(currentTime)
 	case PostMatch:
 		if arena.lastMatchState != PostMatch {
 			// Set the Hub LEDs to white at the end of the match, and then turn them off when the referees are supposed
 			// to assess tower climbs.
-			arena.Leds.SetMode(led.WhiteMode, led.WhiteMode)
+			arena.SetLedMode(led.WhiteMode, led.WhiteMode)
 			go func() {
 				time.Sleep(hubLightScoringAssessmentSec * time.Second)
-				arena.Leds.SetMode(led.OffMode, led.OffMode)
+				arena.SetLedMode(led.OffMode, led.OffMode)
 			}()
 		}
 	}
@@ -101,5 +110,5 @@ func (arena *Arena) updateTeleopHubLeds(currentTime time.Time) {
 			blueMode = led.BlueAdvantageMode
 		}
 	}
-	arena.Leds.SetMode(redMode, blueMode)
+	arena.SetLedMode(redMode, blueMode)
 }

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -384,13 +384,6 @@ func (arena *Arena) generateScoringStatusMessage() any {
 func (arena *Arena) generateLedModeMessage() interface{} {
 	redMode, blueMode := arena.Leds.GetModes()
 
-	log.Printf("Generating LED mode message with RedMode=%d and BlueMode=%d", redMode, blueMode)
-
-	// Only notify if mode has actually changed
-	if redMode == arena.lastRedLedMode && blueMode == arena.lastBlueLedMode {
-		// return nil      // Return nil to suppress the notification
-	}
-
 	arena.lastRedLedMode = redMode
 	arena.lastBlueLedMode = blueMode
 

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -30,6 +30,7 @@ type ArenaNotifiers struct {
 	ReloadDisplaysNotifier             *websocket.Notifier
 	ScorePostedNotifier                *websocket.Notifier
 	ScoringStatusNotifier              *websocket.Notifier
+	LedChangeNotifier 				   *websocket.Notifier
 }
 
 type MatchTimeMessage struct {
@@ -67,6 +68,7 @@ func (arena *Arena) configureNotifiers() {
 	arena.ReloadDisplaysNotifier = websocket.NewNotifier("reload", nil)
 	arena.ScorePostedNotifier = websocket.NewNotifier("scorePosted", arena.GenerateScorePostedMessage)
 	arena.ScoringStatusNotifier = websocket.NewNotifier("scoringStatus", arena.generateScoringStatusMessage)
+	arena.LedChangeNotifier = websocket.NewNotifier("setLedMode", arena.generateLedModeMessage)
 }
 
 func (arena *Arena) generateAllianceSelectionMessage() any {
@@ -377,6 +379,25 @@ func (arena *Arena) generateScoringStatusMessage() any {
 			"blue": getStatusForPosition("blue"),
 		},
 	}
+}
+
+func (arena *Arena) generateLedModeMessage() interface{} {
+    redMode, blueMode := arena.Leds.GetModes()
+
+	log.Printf("Generating LED mode message with RedMode=%d and BlueMode=%d", redMode, blueMode)
+
+    // Only notify if mode has actually changed
+    if redMode == arena.lastRedLedMode && blueMode == arena.lastBlueLedMode {
+       // return nil      // Return nil to suppress the notification
+    }
+
+    arena.lastRedLedMode  = redMode
+    arena.lastBlueLedMode = blueMode
+
+    return map[string]interface{}{
+        "RedMode":  redMode,
+        "BlueMode": blueMode,
+    }
 }
 
 // Constructs the data object for one alliance sent to the audience display for the realtime scoring overlay.

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -30,7 +30,7 @@ type ArenaNotifiers struct {
 	ReloadDisplaysNotifier             *websocket.Notifier
 	ScorePostedNotifier                *websocket.Notifier
 	ScoringStatusNotifier              *websocket.Notifier
-	LedChangeNotifier 				   *websocket.Notifier
+	LedChangeNotifier                  *websocket.Notifier
 }
 
 type MatchTimeMessage struct {
@@ -382,22 +382,22 @@ func (arena *Arena) generateScoringStatusMessage() any {
 }
 
 func (arena *Arena) generateLedModeMessage() interface{} {
-    redMode, blueMode := arena.Leds.GetModes()
+	redMode, blueMode := arena.Leds.GetModes()
 
 	log.Printf("Generating LED mode message with RedMode=%d and BlueMode=%d", redMode, blueMode)
 
-    // Only notify if mode has actually changed
-    if redMode == arena.lastRedLedMode && blueMode == arena.lastBlueLedMode {
-       // return nil      // Return nil to suppress the notification
-    }
+	// Only notify if mode has actually changed
+	if redMode == arena.lastRedLedMode && blueMode == arena.lastBlueLedMode {
+		// return nil      // Return nil to suppress the notification
+	}
 
-    arena.lastRedLedMode  = redMode
-    arena.lastBlueLedMode = blueMode
+	arena.lastRedLedMode = redMode
+	arena.lastBlueLedMode = blueMode
 
-    return map[string]interface{}{
-        "RedMode":  redMode,
-        "BlueMode": blueMode,
-    }
+	return map[string]interface{}{
+		"RedMode":  redMode,
+		"BlueMode": blueMode,
+	}
 }
 
 // Constructs the data object for one alliance sent to the audience display for the realtime scoring overlay.

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -76,7 +76,7 @@ var handleArenaStatus = function (data) {
 };
 
 // Handles a websocket message to update the LED mode selection.
-var handLEDModeChange = function (data) {
+var handleLEDModeChange = function (data) {
   $("input[name=redLedMode][value=" + data.RedMode + "]").prop("checked", true);
   $("input[name=blueLedMode][value=" + data.BlueMode + "]").prop("checked", true);
 }
@@ -103,7 +103,7 @@ $(function () {
       handleArenaStatus(event.data);
     },
     setLedMode: function (event) {
-      handLEDModeChange(event.data);
+      handleLEDModeChange(event.data);
     }
   });
 });

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -75,6 +75,12 @@ var handleArenaStatus = function (data) {
   updateCoilOverrideTooltips();
 };
 
+// Handles a websocket message to update the LED mode selection.
+var handLEDModeChange = function (data) {
+  $("input[name=redLedMode][value=" + data.RedMode + "]").prop("checked", true);
+  $("input[name=blueLedMode][value=" + data.BlueMode + "]").prop("checked", true);
+}
+
 $(function () {
   updateCoilOverrideTooltips();
 
@@ -95,6 +101,9 @@ $(function () {
     },
     arenaStatus: function (event) {
       handleArenaStatus(event.data);
+    },
+    setLedMode: function (event) {
+      handLEDModeChange(event.data);
     }
   });
 });

--- a/web/setup_field_testing.go
+++ b/web/setup_field_testing.go
@@ -76,7 +76,7 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 	defer closeWebsocket(ws)
 
 	// Subscribe the websocket to the notifiers whose messages will be passed on to the client, in a separate goroutine.
-	go ws.HandleNotifiers(web.arena.Plc.IoChangeNotifier(), web.arena.ArenaStatusNotifier)
+	go ws.HandleNotifiers(web.arena.Plc.IoChangeNotifier(), web.arena.ArenaStatusNotifier, web.arena.LedChangeNotifier)
 
 	// Loop, waiting for commands and responding to them, until the client closes the connection.
 	for {
@@ -148,7 +148,7 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 				continue
 			}
 
-			web.arena.Leds.SetMode(args.RedMode, args.BlueMode)
+			web.arena.SetLedMode(args.RedMode, args.BlueMode)
 		default:
 			writeWebsocketError(ws, fmt.Sprintf("Invalid message type '%s'.", messageType))
 			continue

--- a/web/setup_field_testing_test.go
+++ b/web/setup_field_testing_test.go
@@ -137,7 +137,7 @@ func TestSetupFieldTestingWebsocketSetPlcCoilOverrideDisallowedStates(t *testing
 	} {
 		web.arena.MatchState = matchState
 		ws.Write("setPlcCoilOverride", map[string]any{"Index": 8, "Override": "on"})
-		assert.Equal(t, fieldTestingOverrideDisabledMessage, readWebsocketError(t, ws))
+		assert.Equal(t, fieldTestingOverrideDisabledMessage, readFieldTestingWebsocketError(t, ws))
 	}
 }
 
@@ -154,7 +154,7 @@ func TestSetupFieldTestingWebsocketSetPlcCoilOverrideInvalidArgs(t *testing.T) {
 	readWebsocketMultiple(t, ws, 2)
 
 	ws.Write("setPlcCoilOverride", map[string]any{"Index": 8, "Override": "invalid"})
-	assert.Equal(t, "Invalid coil override state 'invalid'.", readWebsocketError(t, ws))
+	assert.Equal(t, "Invalid coil override state 'invalid'.", readFieldTestingWebsocketError(t, ws))
 }
 
 func TestSetupFieldTestingWebsocketSetLedMode(t *testing.T) {
@@ -196,7 +196,7 @@ func TestSetupFieldTestingWebsocketSetLedModeDisallowedStates(t *testing.T) {
 	} {
 		web.arena.MatchState = matchState
 		ws.Write("setLedMode", map[string]any{"RedMode": led.PurpleMode, "BlueMode": led.GreenMode})
-		assert.Equal(t, fieldTestingLedModeDisabledMessage, readWebsocketError(t, ws))
+		assert.Equal(t, fieldTestingLedModeDisabledMessage, readFieldTestingWebsocketError(t, ws))
 	}
 }
 
@@ -213,14 +213,18 @@ func TestSetupFieldTestingWebsocketSetLedModeInvalidArgs(t *testing.T) {
 	readWebsocketMultiple(t, ws, 2)
 
 	ws.Write("setLedMode", map[string]any{"RedMode": 999, "BlueMode": led.GreenMode})
-	assert.Equal(t, "Invalid LED mode '999'.", readWebsocketError(t, ws))
+	assert.Equal(t, "Invalid LED mode '999'.", readFieldTestingWebsocketError(t, ws))
 
 	ws.Write("setLedMode", map[string]any{"RedMode": led.PurpleMode, "BlueMode": 999})
-	assert.Equal(t, "Invalid LED mode '999'.", readWebsocketError(t, ws))
+	assert.Equal(t, "Invalid LED mode '999'.", readFieldTestingWebsocketError(t, ws))
 }
 
 func readPlcIoChangeMessage(t *testing.T, ws *websocket.Websocket) plcIoChangeMessage {
 	var message plcIoChangeMessage
-	assert.Nil(t, mapstructure.Decode(readWebsocketType(t, ws, "plcIoChange"), &message))
+	assert.Nil(t, mapstructure.Decode(readWebsocketTypeEventually(t, ws, "plcIoChange", 3), &message))
 	return message
+}
+
+func readFieldTestingWebsocketError(t *testing.T, ws *websocket.Websocket) string {
+	return readWebsocketTypeEventually(t, ws, "error", 3).(string)
 }


### PR DESCRIPTION
I deleted by acidnet while cleaning up old branches, I updated the changes to reflect the suggestion @Kython89 made.

Also, the test should be passing now.

This is the solution I found for resolving issue https://github.com/Team254/cheesy-arena/issues/283

There may be a less intrusive way to do this that fits better into the CA architecture. Also the /setup_field_testing_test now fails because there are multiple WS and not just the "plcIoChange" message. I have had this issue before in other areas I we have adjusted to fit our needs. I would like to see how you would resolve this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time LED mode synchronization to the field testing interface.
  * Centralized LED mode publishing so red/blue LED selections update consistently across server and the client UI.
* **Bug Fixes**
  * Ensured LED mode changes in match/idle and reset flows correctly propagate via the unified LED mode mechanism.
* **Tests**
  * Improved websocket and PLC/LED-related test robustness using more reliable “eventually” reads and retries for error and message assertions.
* **Chores**
  * Standardized Go source line endings via repository attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->