### PR TITLE
Add DMX lighting feedback

### DIFF
--- a/led/controller.go
+++ b/led/controller.go
@@ -81,6 +81,11 @@ func (controller *Controller) GetModes() (Mode, Mode) {
 	return controller.redZone.currentMode, controller.blueZone.currentMode
 }
 
+// GetPixels returns the current RGB color arrays for the red and blue zones.
+func (controller *Controller) GetPixels() ([64]Color, [64]Color) {
+	return controller.redZone.pixels, controller.blueZone.pixels
+}
+
 // Update advances the pixel values through the current sequence and sends a packet if necessary. Should be called from
 // a timed loop.
 func (controller *Controller) Update() error {

--- a/led/mode.go
+++ b/led/mode.go
@@ -20,6 +20,7 @@ const (
 	BlueStartupMode
 	RedAdvantageMode
 	BlueAdvantageMode
+	RainbowMode
 )
 
 var ModeNames = map[Mode]string{
@@ -35,6 +36,7 @@ var ModeNames = map[Mode]string{
 	BlueStartupMode:   "Blue Startup",
 	RedAdvantageMode:  "Red Advantage",
 	BlueAdvantageMode: "Blue Advantage",
+	RainbowMode:       "Rainbow",
 }
 
 // Returns the solid color associated with the given mode.

--- a/led/zone.go
+++ b/led/zone.go
@@ -53,6 +53,8 @@ func (zone *zone) updatePixels() {
 		zone.updateAdvantageMode(Red, zone.counter)
 	case BlueAdvantageMode:
 		zone.updateAdvantageMode(Blue, zone.counter)
+	case RainbowMode:
+		zone.updateRainbowMode(zone.counter)
 	default:
 		zone.updateSingleColorMode(Black)
 	}
@@ -179,5 +181,48 @@ func (zone *zone) sweepFixture(start, counter int, direction fillDirection) {
 		}
 		brightness := 1 - float64(trail)/float64(pixelsPerFixture)
 		zone.pixels[start+pixel] = White.Scale(brightness)
+	}
+}
+
+// updateRainbowMode renders a rotating rainbow pattern counter-clockwise.
+func (zone *zone) updateRainbowMode(counter int) {
+	logicalPixels := numSides * pixelsPerFixture
+
+	for i := 0; i < logicalPixels; i++ {
+		pos := (i - (counter / 2)) % logicalPixels
+		if pos < 0 {
+			pos += logicalPixels
+		}
+
+		h := float64(pos) / float64(logicalPixels) * 6
+		idx := int(h)
+		f := h - float64(idx)
+
+		q := byte(255 * (1 - f))
+		t := byte(255 * f)
+
+		var color Color
+		switch idx % 6 {
+		case 0:
+			color = Color{255, t, 0}
+		case 1:
+			color = Color{q, 255, 0}
+		case 2:
+			color = Color{0, 255, t}
+		case 3:
+			color = Color{0, q, 255}
+		case 4:
+			color = Color{t, 0, 255}
+		case 5:
+			color = Color{255, 0, q}
+		}
+
+		side := i/pixelsPerFixture + 1
+		pixel := i % pixelsPerFixture
+
+		for fixture := 0; fixture < fixturesPerSide; fixture++ {
+			start := ((side-1)*fixturesPerSide + fixture) * pixelsPerFixture
+			zone.pixels[start+pixel] = color
+		}
 	}
 }

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -75,6 +75,45 @@ var handleArenaStatus = function (data) {
   updateCoilOverrideTooltips();
 };
 
+var ledContainers = {};
+
+var handleLedStatus = function (data) {
+  var renderPixels = function(containerId, pixels) {
+    if (!ledContainers[containerId]) {
+      var container = $("#" + containerId);
+      container.css({"display": "flex", "flex-direction": "column", "gap": "4px"});
+      var boxes = [];
+      for (var i = 0; i < 4; i++) {
+        var row = $("<div></div>").css({"display": "flex", "flex-direction": "row", "gap": "2px"});
+        for (var j = 0; j < 8; j++) {
+          var box = $("<div></div>").css({
+            "width": "12px",
+            "height": "12px",
+            "background-color": "black",
+            "border": "1px solid #333"
+          });
+          boxes.push(box);
+          row.append(box);
+        }
+        container.append(row);
+      }
+      ledContainers[containerId] = boxes;
+    }
+    
+    var boxes = ledContainers[containerId];
+    for (var i = 0; i < 4; i++) {
+      for (var j = 0; j < 8; j++) {
+        var pixelIndex = i * 16 + j;
+        var color = pixels[pixelIndex];
+        boxes[i * 8 + j].css("background-color", "rgb(" + color.R + "," + color.G + "," + color.B + ")");
+      }
+    }
+  };
+  
+  renderPixels("redHubPixels", data.Red);
+  renderPixels("blueHubPixels", data.Blue);
+};
+
 $(function () {
   updateCoilOverrideTooltips();
 
@@ -95,6 +134,9 @@ $(function () {
     },
     arenaStatus: function (event) {
       handleArenaStatus(event.data);
+    },
+    ledStatus: function (event) {
+      handleLedStatus(event.data);
     }
   });
 });

--- a/templates/setup_field_testing.html
+++ b/templates/setup_field_testing.html
@@ -30,6 +30,10 @@ UI for testing the game sounds and the LEDs and PLC connected to the field.
             <label class="form-check-label" for="redLedMode{{$mode}}">{{$name}}</label>
           </div>
           {{end}}
+          <div class="mt-3">
+            <h6 class="text-muted">Live Status</h6>
+            <div id="redHubPixels"></div>
+          </div>
         </div>
         <div class="col">
           <h6>Blue Hub</h6>
@@ -40,6 +44,10 @@ UI for testing the game sounds and the LEDs and PLC connected to the field.
             <label class="form-check-label" for="blueLedMode{{$mode}}">{{$name}}</label>
           </div>
           {{end}}
+          <div class="mt-3">
+            <h6 class="text-muted">Live Status</h6>
+            <div id="blueHubPixels"></div>
+          </div>
         </div>
       </div>
     </div>

--- a/web/setup_field_testing.go
+++ b/web/setup_field_testing.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 )
 
 const (
@@ -77,6 +78,22 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 
 	// Subscribe the websocket to the notifiers whose messages will be passed on to the client, in a separate goroutine.
 	go ws.HandleNotifiers(web.arena.Plc.IoChangeNotifier(), web.arena.ArenaStatusNotifier)
+
+	// Stream the LED status to the client periodically.
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for range ticker.C {
+			redPixels, bluePixels := web.arena.Leds.GetPixels()
+			err := ws.Write("ledStatus", map[string]interface{}{
+				"Red":  redPixels,
+				"Blue": bluePixels,
+			})
+			if err != nil {
+				return
+			}
+		}
+	}()
 
 	// Loop, waiting for commands and responding to them, until the client closes the connection.
 	for {


### PR DESCRIPTION
Add DMX lighting feedback to the field test page.

Also add a rainbow mode for the DMX lighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Rainbow** display mode with a rotating counter-clockwise color pattern across the LED zone.
  * Added **Live Status** to the field testing interface, showing real-time red and blue LED pixels in a grid via websocket updates.  
* **Bug Fixes**
  * (None)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->