### PR TITLE
Add side LED test modes and UI sync

### DIFF
--- a/led/controller.go
+++ b/led/controller.go
@@ -94,8 +94,8 @@ func (controller *Controller) Update() error {
 		return nil
 	}
 
-	controller.redZone.updatePixels()
-	controller.blueZone.updatePixels()
+	controller.redZone.updatePixels(Red)
+	controller.blueZone.updatePixels(Blue)
 
 	// Create the template packet if it doesn't already exist.
 	if len(controller.packet) == 0 {

--- a/led/controller_test.go
+++ b/led/controller_test.go
@@ -135,7 +135,7 @@ func TestStartupModeFillsSidesInFmsOrder(t *testing.T) {
 	controller.SetMode(RedStartupMode, OffMode)
 
 	controller.redZone.counter = 50
-	controller.redZone.updatePixels()
+	controller.redZone.updatePixels(Red)
 
 	assert.Equal(t, Red, controller.redZone.pixels[3])
 	assert.Equal(t, Red, controller.redZone.pixels[4])
@@ -149,7 +149,7 @@ func TestAdvantageModeSweepsInOppositeDirectionsBySide(t *testing.T) {
 	controller.SetMode(RedAdvantageMode, OffMode)
 
 	controller.redZone.counter = advantageStepCycle
-	controller.redZone.updatePixels()
+	controller.redZone.updatePixels(Red)
 
 	assert.Equal(t, White, controller.redZone.pixels[0])
 	assert.Equal(t, White, controller.redZone.pixels[31])
@@ -159,11 +159,11 @@ func TestPulseModeScalesAllianceColor(t *testing.T) {
 	controller := NewController()
 	controller.SetMode(RedPulseMode, OffMode)
 
-	controller.redZone.updatePixels()
+	controller.redZone.updatePixels(Red)
 	assert.Equal(t, Black, controller.redZone.pixels[0])
 
 	controller.redZone.counter = pulseHalfPeriod
-	controller.redZone.updatePixels()
+	controller.redZone.updatePixels(Red)
 	assert.Equal(t, Red, controller.redZone.pixels[0])
 }
 

--- a/led/mode.go
+++ b/led/mode.go
@@ -21,6 +21,10 @@ const (
 	RedAdvantageMode
 	BlueAdvantageMode
 	RainbowMode
+	Side1TestMode
+	Side2TestMode
+	Side3TestMode
+	Side4TestMode
 )
 
 var ModeNames = map[Mode]string{
@@ -37,6 +41,10 @@ var ModeNames = map[Mode]string{
 	RedAdvantageMode:  "Red Advantage",
 	BlueAdvantageMode: "Blue Advantage",
 	RainbowMode:       "Rainbow",
+	Side1TestMode:     "Test: Facing Driver Station",
+	Side2TestMode:     "Test: Facing Audience",
+	Side3TestMode:     "Test: Facing Center",
+	Side4TestMode:     "Test: Facing Scoring Table",
 }
 
 // Returns the solid color associated with the given mode.

--- a/led/zone.go
+++ b/led/zone.go
@@ -37,7 +37,7 @@ type zone struct {
 }
 
 // updatePixels calculates the current pixel values depending on the mode and elapsed counter cycles.
-func (zone *zone) updatePixels() {
+func (zone *zone) updatePixels(baseColor Color) {
 	switch zone.currentMode {
 	case RedMode, BlueMode, GreenMode, PurpleMode, WhiteMode, OffMode:
 		zone.updateSingleColorMode(colorForMode(zone.currentMode))
@@ -49,12 +49,15 @@ func (zone *zone) updatePixels() {
 		zone.updateStartupMode(Red, zone.counter)
 	case BlueStartupMode:
 		zone.updateStartupMode(Blue, zone.counter)
+
 	case RedAdvantageMode:
 		zone.updateAdvantageMode(Red, zone.counter)
 	case BlueAdvantageMode:
 		zone.updateAdvantageMode(Blue, zone.counter)
 	case RainbowMode:
 		zone.updateRainbowMode(zone.counter)
+	case Side1TestMode, Side2TestMode, Side3TestMode, Side4TestMode:
+		zone.updateSideTestMode(int(zone.currentMode-Side1TestMode)+1, baseColor)
 	default:
 		zone.updateSingleColorMode(Black)
 	}
@@ -224,5 +227,14 @@ func (zone *zone) updateRainbowMode(counter int) {
 			start := ((side-1)*fixturesPerSide + fixture) * pixelsPerFixture
 			zone.pixels[start+pixel] = color
 		}
+	}
+}
+
+func (zone *zone) updateSideTestMode(sideToTest int, color Color) {
+	zone.updateSingleColorMode(Black)
+	startIndex := (sideToTest - 1) * fixturesPerSide * pixelsPerFixture
+	endIndex := startIndex + (fixturesPerSide * pixelsPerFixture)
+	for i := startIndex; i < endIndex; i++ {
+		zone.pixels[i] = color
 	}
 }

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -7,6 +7,7 @@ var websocket;
 var plcOverrideAllowed = false;
 var allowedOverrideMatchStates = [0, 5, 6, 7];
 var disabledOverrideTooltipText = "Cannot override coil while match is in progress.";
+var disabledLedTooltipText = "Cannot override LED Lighting while match is in progress.";
 
 // Sends a websocket message to play a given game sound on the audience display.
 var playSound = function (sound) {
@@ -16,8 +17,8 @@ var playSound = function (sound) {
 // Sends a websocket message to set the selected LED test mode.
 var setLedMode = function () {
   websocket.send("setLedMode", {
-    RedMode: parseInt($("input[name=redLedMode]:checked").val(), 10),
-    BlueMode: parseInt($("input[name=blueLedMode]:checked").val(), 10)
+    RedMode: parseInt(modeSelects["red"].val(), 10),
+    BlueMode: parseInt(modeSelects["blue"].val(), 10)
   });
 };
 
@@ -51,6 +52,19 @@ var updateCoilOverrideTooltips = function () {
   });
 };
 
+var updateLedOverrideTooltips = function () {
+  $(".led-mode-wrapper").each(function (_index, element) {
+    const tooltip = bootstrap.Tooltip.getInstance(element);
+    if (plcOverrideAllowed) {
+      if (tooltip) {
+        tooltip.dispose();
+      }
+    } else if (!tooltip) {
+      new bootstrap.Tooltip(element, { title: disabledLedTooltipText });
+    }
+  });
+};
+
 // Handles a websocket message to update the PLC IO status.
 var handlePlcIoChange = function (data) {
   $.each(data.Inputs, function (index, input) {
@@ -73,9 +87,15 @@ var handlePlcIoChange = function (data) {
 var handleArenaStatus = function (data) {
   plcOverrideAllowed = allowedOverrideMatchStates.includes(data.MatchState);
   updateCoilOverrideTooltips();
+  updateLedOverrideTooltips();
+  
+  modeSelects["red"].prop("disabled", !plcOverrideAllowed);
+  modeSelects["blue"].prop("disabled", !plcOverrideAllowed);
 };
 
 var ledContainers = {};
+var modeSelects = {};
+var lastServerModes = {};
 
 var handleLedStatus = function (data) {
   var renderPixels = function(containerId, pixels) {
@@ -112,10 +132,24 @@ var handleLedStatus = function (data) {
   
   renderPixels("redHubPixels", data.Red);
   renderPixels("blueHubPixels", data.Blue);
+  
+  var syncModeSelect = function(alliance, mode) {
+    if (lastServerModes[alliance] !== mode) {
+      modeSelects[alliance].val(mode);
+      lastServerModes[alliance] = mode;
+    }
+  };
+  
+  syncModeSelect("red", data.RedMode);
+  syncModeSelect("blue", data.BlueMode);
 };
 
 $(function () {
+  modeSelects["red"] = $("select[name=redLedMode]");
+  modeSelects["blue"] = $("select[name=blueLedMode]");
+  
   updateCoilOverrideTooltips();
+  updateLedOverrideTooltips();
 
   $(document).on("click", ".plc-coil-indicator", function (event) {
     if (!plcOverrideAllowed) {

--- a/static/js/setup_field_testing.js
+++ b/static/js/setup_field_testing.js
@@ -134,7 +134,7 @@ var handleLedStatus = function (data) {
   renderPixels("blueHubPixels", data.Blue);
   
   var syncModeSelect = function(alliance, mode) {
-    if (lastServerModes[alliance] !== mode) {
+    if (lastServerModes[alliance] !== mode || modeSelects[alliance].val() != mode) {
       modeSelects[alliance].val(mode);
       lastServerModes[alliance] = mode;
     }

--- a/templates/setup_field_testing.html
+++ b/templates/setup_field_testing.html
@@ -23,13 +23,15 @@ UI for testing the game sounds and the LEDs and PLC connected to the field.
       <div class="row">
         <div class="col">
           <h6>Red Hub</h6>
-          {{range $mode, $name := .LedModeNames}}
-          <div class="form-check">
-            <input class="form-check-input led-mode" type="radio" name="redLedMode" id="redLedMode{{$mode}}"
-              value="{{$mode}}" onchange="setLedMode();" {{if eq $mode $.RedLedMode}}checked{{end}}>
-            <label class="form-check-label" for="redLedMode{{$mode}}">{{$name}}</label>
+          <div class="form-group">
+            <span class="d-inline-block w-100 led-mode-wrapper" tabindex="0">
+              <select class="form-select led-mode" name="redLedMode" id="redLedModeSelect" onchange="setLedMode();">
+                {{range $mode, $name := .LedModeNames}}
+                <option value="{{$mode}}" {{if eq $mode $.RedLedMode}}selected{{end}}>{{$name}}</option>
+                {{end}}
+              </select>
+            </span>
           </div>
-          {{end}}
           <div class="mt-3">
             <h6 class="text-muted">Live Status</h6>
             <div id="redHubPixels"></div>
@@ -37,13 +39,15 @@ UI for testing the game sounds and the LEDs and PLC connected to the field.
         </div>
         <div class="col">
           <h6>Blue Hub</h6>
-          {{range $mode, $name := .LedModeNames}}
-          <div class="form-check">
-            <input class="form-check-input led-mode" type="radio" name="blueLedMode" id="blueLedMode{{$mode}}"
-              value="{{$mode}}" onchange="setLedMode();" {{if eq $mode $.BlueLedMode}}checked{{end}}>
-            <label class="form-check-label" for="blueLedMode{{$mode}}">{{$name}}</label>
+          <div class="form-group">
+            <span class="d-inline-block w-100 led-mode-wrapper" tabindex="0">
+              <select class="form-select led-mode" name="blueLedMode" id="blueLedModeSelect" onchange="setLedMode();">
+                {{range $mode, $name := .LedModeNames}}
+                <option value="{{$mode}}" {{if eq $mode $.BlueLedMode}}selected{{end}}>{{$name}}</option>
+                {{end}}
+              </select>
+            </span>
           </div>
-          {{end}}
           <div class="mt-3">
             <h6 class="text-muted">Live Status</h6>
             <div id="blueHubPixels"></div>

--- a/web/setup_field_testing.go
+++ b/web/setup_field_testing.go
@@ -85,9 +85,18 @@ func (web *Web) fieldTestingWebsocketHandler(w http.ResponseWriter, r *http.Requ
 		defer ticker.Stop()
 		for range ticker.C {
 			redPixels, bluePixels := web.arena.Leds.GetPixels()
-			err := ws.Write("ledStatus", map[string]interface{}{
-				"Red":  redPixels,
-				"Blue": bluePixels,
+			redMode, blueMode := web.arena.Leds.GetModes()
+			type ledStatusPayload struct {
+				Red      [64]led.Color
+				Blue     [64]led.Color
+				RedMode  led.Mode
+				BlueMode led.Mode
+			}
+			err := ws.Write("ledStatus", ledStatusPayload{
+				Red:      redPixels,
+				Blue:     bluePixels,
+				RedMode:  redMode,
+				BlueMode: blueMode,
 			})
 			if err != nil {
 				return


### PR DESCRIPTION
Introduce four side test modes and support for selecting/testing a single side. 
Replace radio buttons with select dropdowns in setup UI. 
Add disabling of LED controls while match is in progress, and sync/reflect server-side modes in the selects. Websocket payload for ledStatus now includes RedMode and BlueMode and the frontend handles them to keep the UI state consistent.

Closes #292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added side-specific LED test modes to support more detailed field testing for different facing directions.

* **Improvements**
  * Updated the field testing UI LED mode controls from radio buttons to dropdown menus.
  * Improved LED override tooltip behavior and refreshed tooltips based on override availability.
  * Enhanced real-time LED mode synchronization so the UI stays consistent with the current Red/Blue hub modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->