### PR TITLE
Add support for Head Ref E-Stop

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -113,6 +113,7 @@ type AllianceStation struct {
 	Ethernet     bool
 	AStop        bool
 	EStop        bool
+	RefEStop     bool
 	Bypass       bool
 	Team         *model.Team
 	WifiStatus   network.TeamWifiStatus
@@ -960,6 +961,12 @@ func (arena *Arena) assignTeam(teamId int, station string) error {
 	// Force the A-stop to be reset by the new team if it is already pressed (if the PLC is enabled).
 	arena.AllianceStations[station].aStopReset = !arena.Plc.IsEnabled()
 
+	if !arena.Plc.IsEnabled() {
+		// If we're not on PLC, force the E-Stop to be reset
+		arena.AllianceStations[station].RefEStop = false
+		arena.AllianceStations[station].EStop = false
+	}
+
 	// Do nothing if the station is already assigned to the requested team.
 	dsConn := arena.AllianceStations[station].DsConn
 	if dsConn != nil && dsConn.TeamId == teamId {
@@ -1154,6 +1161,7 @@ func (arena *Arena) sendDsPacket(auto bool, enabled bool) {
 			dsConn.Enabled = enabled && !allianceStation.EStop && !(auto && allianceStation.AStop) &&
 				!allianceStation.Bypass
 			dsConn.EStop = allianceStation.EStop
+			dsConn.RefEStop = allianceStation.RefEStop
 			dsConn.AStop = allianceStation.AStop
 			err := dsConn.update(arena, allianceStation.GameData)
 			if err != nil {
@@ -1334,6 +1342,16 @@ func (arena *Arena) ToggleBypass(station string) error {
 	return nil
 }
 
+func (arena *Arena) SetRefEStop(station string) error {
+	if _, ok := arena.AllianceStations[station]; !ok {
+		return fmt.Errorf("Invalid alliance station '%s'.", station)
+	}
+	arena.AllianceStations[station].EStop = true
+	arena.AllianceStations[station].RefEStop = true
+	arena.ArenaStatusNotifier.Notify()
+	return nil
+}
+
 func (arena *Arena) handleTeamStop(station string, eStopState, aStopState bool) {
 	allianceStation := arena.AllianceStations[station]
 	if eStopState {
@@ -1341,6 +1359,7 @@ func (arena *Arena) handleTeamStop(station string, eStopState, aStopState bool) 
 	} else if arena.MatchTimeSec() == 0 {
 		// Keep the E-stop latched until the match is over.
 		allianceStation.EStop = false
+		allianceStation.RefEStop = false
 	}
 	if aStopState {
 		allianceStation.AStop = true

--- a/field/driver_station_connection.go
+++ b/field/driver_station_connection.go
@@ -42,6 +42,7 @@ type DriverStationConnection struct {
 	Auto                      bool
 	Enabled                   bool
 	EStop                     bool
+	RefEStop                  bool
 	AStop                     bool
 	DsLinked                  bool
 	RadioLinked               bool
@@ -252,6 +253,11 @@ func (dsConn *DriverStationConnection) encodeControlPacket(arena *Arena, gameDat
 	}
 	if dsConn.Enabled {
 		packet[3] |= 0x04
+	}
+	if dsConn.newDs {
+		if dsConn.RefEStop {
+			packet[3] |= 0x20
+		}
 	}
 	if dsConn.EStop {
 		packet[3] |= 0x80

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -208,6 +208,17 @@ func (web *Web) refereePanelWebsocketHandler(w http.ResponseWriter, r *http.Requ
 				writeWebsocketError(ws, err.Error())
 				continue
 			}
+		case "refEStop":
+			station, ok := data.(string)
+			if !ok {
+				writeWebsocketError(ws, fmt.Sprintf("Failed to parse '%s' message.", messageType))
+				continue
+			}
+			err = web.arena.SetRefEStop(station)
+			if err != nil {
+				writeWebsocketError(ws, err.Error())
+				continue
+			}
 		case "signalVolunteers":
 			web.arena.SignalVolunteers()
 		case "signalReset":


### PR DESCRIPTION
This doesn't actually change the Head Ref display to actually be able to set these values. I'm not sure of the right way to do that, I don't know HTML at all. Ideally, while the match is running, the display should switch from "Bypass" to "E-Stop" and switch to doing this. Additionally, it'd be good if the scorekeeper estop also uses this as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a separate referee emergency-stop state per alliance station.
  * Referee controls can now trigger this stop state from the web panel.

* **Bug Fixes**
  * Station emergency-stop states are now reset correctly when a team is assigned while the control system is disabled.
  * The stop state is now cleared consistently when a match ends.
  * Driver station updates now include the new emergency-stop status for supported connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->