### PR TITLE
Fix/preserve field signal on match load

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -7,13 +7,6 @@ package field
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena/game"
-	"github.com/Team254/cheesy-arena/led"
-	"github.com/Team254/cheesy-arena/model"
-	"github.com/Team254/cheesy-arena/network"
-	"github.com/Team254/cheesy-arena/partner"
-	"github.com/Team254/cheesy-arena/playoff"
-	"github.com/Team254/cheesy-arena/plc"
 	"log"
 	"math"
 	"math/rand"
@@ -22,6 +15,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Team254/cheesy-arena/game"
+	"github.com/Team254/cheesy-arena/led"
+	"github.com/Team254/cheesy-arena/model"
+	"github.com/Team254/cheesy-arena/network"
+	"github.com/Team254/cheesy-arena/partner"
+	"github.com/Team254/cheesy-arena/playoff"
+	"github.com/Team254/cheesy-arena/plc"
 )
 
 const (
@@ -401,8 +402,7 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.Plc.ResetMatch()
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
-	// Preserve an active field-reset/volunteers signal across the match load (e.g. after committing scores)
-	// rather than blanking the field LEDs out from under the head referee.
+	// Preserve current field LED state across the match load (e.g. after committing scores)
 	if arena.FieldReset {
 		arena.Leds.SetMode(led.GreenMode, led.GreenMode)
 	} else if arena.FieldVolunteers {

--- a/field/arena.go
+++ b/field/arena.go
@@ -401,7 +401,15 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.Plc.ResetMatch()
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
-	arena.Leds.SetMode(led.OffMode, led.OffMode)
+	// Preserve an active field-reset/volunteers signal across the match load (e.g. after committing scores)
+	// rather than blanking the field LEDs out from under the head referee.
+	if arena.FieldReset {
+		arena.Leds.SetMode(led.GreenMode, led.GreenMode)
+	} else if arena.FieldVolunteers {
+		arena.Leds.SetMode(led.PurpleMode, led.PurpleMode)
+	} else {
+		arena.Leds.SetMode(led.OffMode, led.OffMode)
+	}
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()

--- a/field/arena.go
+++ b/field/arena.go
@@ -402,19 +402,21 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.Plc.ResetMatch()
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
-	// Preserve current field LED state across the match load (e.g. after committing scores)
+	// Preserve current field state across the match load and set the states (e.g. after committing scores)
 	if arena.FieldReset {
 		arena.Leds.SetMode(led.GreenMode, led.GreenMode)
+		arena.AllianceStationDisplayMode = "fieldReset"
 	} else if arena.FieldVolunteers {
 		arena.Leds.SetMode(led.PurpleMode, led.PurpleMode)
+		arena.AllianceStationDisplayMode = "signalCount"
 	} else {
 		arena.Leds.SetMode(led.OffMode, led.OffMode)
+		arena.AllianceStationDisplayMode = "match"
 	}
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()
 	arena.RealtimeScoreNotifier.Notify()
-	arena.AllianceStationDisplayMode = "match"
 	arena.AllianceStationDisplayModeNotifier.Notify()
 	arena.ScoringStatusNotifier.Notify()
 

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -4,6 +4,12 @@
 package field
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/Team254/cheesy-arena/game"
 	"github.com/Team254/cheesy-arena/led"
 	"github.com/Team254/cheesy-arena/model"
@@ -12,11 +18,6 @@ import (
 	"github.com/Team254/cheesy-arena/tournament"
 	"github.com/Team254/cheesy-arena/websocket"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
 )
 
 func TestAssignTeam(t *testing.T) {
@@ -1310,8 +1311,7 @@ func TestSignalReset(t *testing.T) {
 	assertHubLedModes(led.GreenMode, led.GreenMode)
 }
 
-// Loading the next match (as happens when committing and posting match results) should not clobber an
-// active field-reset or volunteers signal that the head referee gave before the score was committed.
+// Test loading match preserves field signal state (green safe/purple count)
 func TestLoadMatchPreservesFieldSignalLeds(t *testing.T) {
 	arena := setupTestArena(t)
 	assertHubLedModes := func(red, blue led.Mode) {

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -1309,3 +1309,32 @@ func TestSignalReset(t *testing.T) {
 	assert.Equal(t, "fieldReset", arena.AllianceStationDisplayMode)
 	assertHubLedModes(led.GreenMode, led.GreenMode)
 }
+
+// Loading the next match (as happens when committing and posting match results) should not clobber an
+// active field-reset or volunteers signal that the head referee gave before the score was committed.
+func TestLoadMatchPreservesFieldSignalLeds(t *testing.T) {
+	arena := setupTestArena(t)
+	assertHubLedModes := func(red, blue led.Mode) {
+		redMode, blueMode := arena.Leds.GetModes()
+		assert.Equal(t, red, redMode)
+		assert.Equal(t, blue, blueMode)
+	}
+
+	// No active signal -- LEDs should be off after loading a match.
+	arena.FieldReset = false
+	arena.FieldVolunteers = false
+	arena.Leds.SetMode(led.RedMode, led.BlueMode)
+	assert.Nil(t, arena.LoadMatch(new(model.Match)))
+	assertHubLedModes(led.OffMode, led.OffMode)
+
+	// An active field-reset signal should carry over.
+	arena.FieldReset = true
+	assert.Nil(t, arena.LoadMatch(new(model.Match)))
+	assertHubLedModes(led.GreenMode, led.GreenMode)
+
+	// An active volunteers signal should carry over.
+	arena.FieldReset = false
+	arena.FieldVolunteers = true
+	assert.Nil(t, arena.LoadMatch(new(model.Match)))
+	assertHubLedModes(led.PurpleMode, led.PurpleMode)
+}

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -1320,21 +1320,27 @@ func TestLoadMatchPreservesFieldSignalLeds(t *testing.T) {
 		assert.Equal(t, blue, blueMode)
 	}
 
-	// No active signal -- LEDs should be off after loading a match.
+	// No active signal -- LEDs and alliance station display should reset to "match" after loading a match.
 	arena.FieldReset = false
 	arena.FieldVolunteers = false
 	arena.Leds.SetMode(led.RedMode, led.BlueMode)
+	arena.AllianceStationDisplayMode = "logo"
 	assert.Nil(t, arena.LoadMatch(new(model.Match)))
 	assertHubLedModes(led.OffMode, led.OffMode)
+	assert.Equal(t, "match", arena.AllianceStationDisplayMode)
 
-	// An active field-reset signal should carry over.
+	// An active field-reset signal should carry over to both the LEDs and the alliance station display.
 	arena.FieldReset = true
+	arena.AllianceStationDisplayMode = "match"
 	assert.Nil(t, arena.LoadMatch(new(model.Match)))
 	assertHubLedModes(led.GreenMode, led.GreenMode)
+	assert.Equal(t, "fieldReset", arena.AllianceStationDisplayMode)
 
-	// An active volunteers signal should carry over.
+	// An active volunteers signal should carry over to both the LEDs and the alliance station display.
 	arena.FieldReset = false
 	arena.FieldVolunteers = true
+	arena.AllianceStationDisplayMode = "match"
 	assert.Nil(t, arena.LoadMatch(new(model.Match)))
 	assertHubLedModes(led.PurpleMode, led.PurpleMode)
+	assert.Equal(t, "signalCount", arena.AllianceStationDisplayMode)
 }

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -1313,34 +1313,57 @@ func TestSignalReset(t *testing.T) {
 
 // Test loading match preserves field signal state (green safe/purple count)
 func TestLoadMatchPreservesFieldSignalLeds(t *testing.T) {
-	arena := setupTestArena(t)
-	assertHubLedModes := func(red, blue led.Mode) {
-		redMode, blueMode := arena.Leds.GetModes()
-		assert.Equal(t, red, redMode)
-		assert.Equal(t, blue, blueMode)
+	tests := []struct {
+		name                string
+		fieldReset          bool
+		fieldVolunteers     bool
+		initialDisplayMode  string
+		expectedLedMode     led.Mode
+		expectedDisplayMode string
+	}{
+		{
+			// No active signal -- LEDs and alliance station display should reset to "match" after loading a match.
+			name:                "No active signal resets to match",
+			fieldReset:          false,
+			fieldVolunteers:     false,
+			initialDisplayMode:  "logo",
+			expectedLedMode:     led.OffMode,
+			expectedDisplayMode: "match",
+		},
+		{
+			// An active field-reset signal should carry over to both the LEDs and the alliance station display.
+			name:                "Active field-reset signal carries over",
+			fieldReset:          true,
+			fieldVolunteers:     false,
+			initialDisplayMode:  "match",
+			expectedLedMode:     led.GreenMode,
+			expectedDisplayMode: "fieldReset",
+		},
+		{
+			// An active volunteers signal should carry over to both the LEDs and the alliance station display.
+			name:                "Active volunteers signal carries over",
+			fieldReset:          false,
+			fieldVolunteers:     true,
+			initialDisplayMode:  "match",
+			expectedLedMode:     led.PurpleMode,
+			expectedDisplayMode: "signalCount",
+		},
 	}
 
-	// No active signal -- LEDs and alliance station display should reset to "match" after loading a match.
-	arena.FieldReset = false
-	arena.FieldVolunteers = false
-	arena.Leds.SetMode(led.RedMode, led.BlueMode)
-	arena.AllianceStationDisplayMode = "logo"
-	assert.Nil(t, arena.LoadMatch(new(model.Match)))
-	assertHubLedModes(led.OffMode, led.OffMode)
-	assert.Equal(t, "match", arena.AllianceStationDisplayMode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arena := setupTestArena(t)
+			arena.FieldReset = tt.fieldReset
+			arena.FieldVolunteers = tt.fieldVolunteers
+			arena.Leds.SetMode(led.RedMode, led.BlueMode)
+			arena.AllianceStationDisplayMode = tt.initialDisplayMode
 
-	// An active field-reset signal should carry over to both the LEDs and the alliance station display.
-	arena.FieldReset = true
-	arena.AllianceStationDisplayMode = "match"
-	assert.Nil(t, arena.LoadMatch(new(model.Match)))
-	assertHubLedModes(led.GreenMode, led.GreenMode)
-	assert.Equal(t, "fieldReset", arena.AllianceStationDisplayMode)
+			assert.Nil(t, arena.LoadMatch(new(model.Match)))
 
-	// An active volunteers signal should carry over to both the LEDs and the alliance station display.
-	arena.FieldReset = false
-	arena.FieldVolunteers = true
-	arena.AllianceStationDisplayMode = "match"
-	assert.Nil(t, arena.LoadMatch(new(model.Match)))
-	assertHubLedModes(led.PurpleMode, led.PurpleMode)
-	assert.Equal(t, "signalCount", arena.AllianceStationDisplayMode)
+			redMode, blueMode := arena.Leds.GetModes()
+			assert.Equal(t, tt.expectedLedMode, redMode)
+			assert.Equal(t, tt.expectedLedMode, blueMode)
+			assert.Equal(t, tt.expectedDisplayMode, arena.AllianceStationDisplayMode)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #301

Checks current arena status (field reset/count) on match load and preserves/sets those values rather than clearing to "match" state.

Unless intentional this should stop HR's and Scorekeepers setting the field to "Field Reset" or "Field Count" twice, one before commit and once after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved active field pre-match signals when loading a new match, including correct LED colors and station display modes.
  * Field reset and volunteer signaling indicators now remain correctly reflected on LEDs and station displays.
  * When no pre-match signal is active, indicators still return to the default match/off state.

* **Tests**
  * Added a table-driven test to verify field signal state across match loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->