### PR TITLE
Fix TBA rankings sync

### DIFF
--- a/partner/tba.go
+++ b/partner/tba.go
@@ -99,17 +99,17 @@ type tbaHub struct {
 }
 
 type TbaRanking struct {
-	TeamKey  string `json:"team_key"`
-	Rank     int    `json:"rank"`
-	RP       float32
-	Match    float32
-	AutoFuel float32
-	Tower    float32
-	Wins     int `json:"wins"`
-	Losses   int `json:"losses"`
-	Ties     int `json:"ties"`
-	Dqs      int `json:"dqs"`
-	Played   int `json:"played"`
+	TeamKey  string  `json:"team_key"`
+	Rank     int     `json:"rank"`
+	RP       float32 `json:"RP"`
+	Match    float32 `json:"Match"`
+	AutoFuel float32 `json:"Auto Fuel"`
+	Tower    float32 `json:"Tower"`
+	Wins     int     `json:"wins"`
+	Losses   int     `json:"losses"`
+	Ties     int     `json:"ties"`
+	Dqs      int     `json:"dqs"`
+	Played   int     `json:"played"`
 }
 
 type TbaRankings struct {


### PR DESCRIPTION
Currently TBA returns a 500 error due to incorrect JSON formatting

Issue identified and fix tested at Sunset Showdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected serialized ranking data field names to ensure compatibility with external data exchanges.
  * Preserved existing ranking values while improving JSON output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->