### PR TITLE
Fix field reset lighting when scores are posted before the field is set to green

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -402,7 +402,6 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	arena.Plc.ResetMatch()
 	arena.NextFoulId = 1
 	arena.redWonAuto = false
-	arena.Leds.SetMode(led.OffMode, led.OffMode)
 
 	// Notify any listeners about the new match.
 	arena.MatchLoadNotifier.Notify()
@@ -1293,10 +1292,6 @@ func (arena *Arena) handlePlcInputOutput() {
 	// Handle the evergreen PLC functions: stack lights, stack buzzer, and field reset light.
 	switch arena.MatchState {
 	case PreMatch:
-		if arena.lastMatchState != PreMatch {
-			arena.Plc.SetFieldResetLight(true)
-			arena.Leds.SetMode(led.GreenMode, led.GreenMode)
-		}
 		fallthrough
 	case TimeoutActive:
 		fallthrough
@@ -1422,7 +1417,7 @@ func (arena *Arena) handleTeamStop(station string, eStopState, aStopState bool) 
 
 // Set the field lights and team signs to purple, if not in a match.
 func (arena *Arena) SignalVolunteers() {
-	if arena.MatchState != PostMatch && arena.MatchState != PreMatch {
+	if arena.MatchState != PostMatch && arena.MatchState != PreMatch && arena.MatchState != TimeoutActive {
 		// Don't signal volunteers during matches.
 		return
 	}
@@ -1430,12 +1425,13 @@ func (arena *Arena) SignalVolunteers() {
 	arena.FieldReset = false
 	arena.AllianceStationDisplayMode = "signalCount"
 	arena.AllianceStationDisplayModeNotifier.Notify()
+	arena.Plc.SetFieldResetLight(false)
 	arena.Leds.SetMode(led.PurpleMode, led.PurpleMode)
 }
 
 // Set the field lights and team signs to green, if not in a match.
 func (arena *Arena) SignalReset() {
-	if arena.MatchState != PostMatch && arena.MatchState != PreMatch {
+	if arena.MatchState != PostMatch && arena.MatchState != PreMatch && arena.MatchState != TimeoutActive {
 		// Don't signal reset during matches.
 		return
 	}
@@ -1447,6 +1443,7 @@ func (arena *Arena) SignalReset() {
 	arena.FieldReset = true
 	arena.AllianceStationDisplayMode = "fieldReset"
 	arena.AllianceStationDisplayModeNotifier.Notify()
+	arena.Plc.SetFieldResetLight(true)
 	arena.Leds.SetMode(led.GreenMode, led.GreenMode)
 }
 

--- a/field/arena_test.go
+++ b/field/arena_test.go
@@ -1058,6 +1058,7 @@ func TestPlcMatchCycleGameSpecific(t *testing.T) {
 
 	// Hub counts should be ignored before a match has started, motors should stay off, and the LEDs should signal
 	// field reset.
+	arena.SignalReset()
 	assert.Equal(t, PreMatch, arena.MatchState)
 	plc.redHubCount = 5
 	plc.blueHubCount = 8
@@ -1234,7 +1235,7 @@ func TestSignalVolunteers(t *testing.T) {
 	}
 
 	// Test that SignalVolunteers only works in PreMatch and PostMatch states.
-	for _, state := range []MatchState{StartMatch, AutoPeriod, PausePeriod, TeleopPeriod, TimeoutActive, PostTimeout} {
+	for _, state := range []MatchState{StartMatch, AutoPeriod, PausePeriod, TeleopPeriod, PostTimeout} {
 		arena.MatchState = state
 		arena.FieldVolunteers = false
 		arena.Leds.SetMode(led.OffMode, led.OffMode)
@@ -1275,7 +1276,7 @@ func TestSignalReset(t *testing.T) {
 	}
 
 	// Test that SignalReset only works in PreMatch and PostMatch states.
-	for _, state := range []MatchState{StartMatch, AutoPeriod, PausePeriod, TeleopPeriod, TimeoutActive, PostTimeout} {
+	for _, state := range []MatchState{StartMatch, AutoPeriod, PausePeriod, TeleopPeriod, PostTimeout} {
 		arena.MatchState = state
 		arena.FieldReset = false
 		arena.FieldVolunteers = false

--- a/field/team_sign.go
+++ b/field/team_sign.go
@@ -353,12 +353,8 @@ func (sign *TeamSign) generateTeamNumberTexts(
 			frontColor = orangeColor
 		} else if allianceStation.AStop && arena.MatchState == AutoPeriod {
 			frontColor = blinkColor(orangeColor)
-		} else if arena.MatchState == PreMatch {
-			if station != "" && arena.checkAllianceStationsReady(station) == nil {
-				frontColor = allianceColor
-			} else {
-				frontColor = greenColor
-			}
+		} else if arena.MatchState == PreMatch && station != "" && arena.checkAllianceStationsReady(station) == nil {
+			frontColor = allianceColor
 		} else if arena.FieldReset {
 			frontColor = greenColor
 		} else if arena.FieldVolunteers {

--- a/field/team_sign_test.go
+++ b/field/team_sign_test.go
@@ -309,10 +309,11 @@ func TestTeamSign_TeamNumber(t *testing.T) {
 	assertSign(true, "  254", greenColor, "254       Connect PC")
 	assertSign(false, "  254", greenColor, "254       Connect PC")
 	arena.FieldReset = false
-	assertSign(true, "  254", greenColor, "254       Connect PC")
-	assertSign(false, "  254", greenColor, "254       Connect PC")
+	assertSign(true, "  254", redColor, "254       Connect PC")
+	assertSign(false, "  254", blueColor, "254       Connect PC")
 
 	// Check through pre-match sequence.
+	arena.FieldReset = true
 	allianceStation.Ethernet = true
 	assertSign(true, "  254", greenColor, "254         Start DS")
 	allianceStation.DsConn = &DriverStationConnection{}
@@ -327,12 +328,10 @@ func TestTeamSign_TeamNumber(t *testing.T) {
 	allianceStation.DsConn.RobotLinked = true
 	assertSign(true, "  254", redColor, "254            Ready")
 
-	arena.FieldReset = true
-	assertSign(true, "  254", redColor, "254            Ready")
 	arena.FieldReset = false
 	assertSign(true, "  254", redColor, "254            Ready")
 	allianceStation.DsConn.RobotLinked = false
-	assertSign(true, "  254", greenColor, "254          No Code")
+	assertSign(true, "  254", redColor, "254          No Code")
 	allianceStation.DsConn.RobotLinked = true
 	allianceStation.Bypass = true
 	assertSign(true, "  254", redColor, "254         Bypassed")


### PR DESCRIPTION
Fixes #301 by removing the assumption that when scores are posted the field should be green. Also allows signaling of reset and volunteers while timeouts are running.

Fixes behavior of:
- Team signs
- Hub lights
- Field reset bar light
in the case where scores are posted before the field is set to green.

Tested at Sunset Showdown 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field-reset and volunteer signaling during match transitions and timeouts.
  * Prevented field lights from activating prematurely when entering pre-match.
  * Corrected team sign colors for disconnected or not-ready stations.
  * Team signs now consistently display green during active field-reset signaling and appropriate alliance colors otherwise.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->