### PR TITLE
Turn on Hub lights when Logo/Awards mode is selected

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -663,6 +663,10 @@ func (arena *Arena) SetAllianceStationDisplayMode(mode string) {
 	if arena.AllianceStationDisplayMode != mode {
 		arena.AllianceStationDisplayMode = mode
 		arena.AllianceStationDisplayModeNotifier.Notify()
+
+		if mode == "logo" {
+			arena.Leds.SetMode(led.RedMode, led.BlueMode)
+		}
 	}
 }
 


### PR DESCRIPTION
Sets the red hub to red and the blue hub to blue when Logo/Awards is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alliance-station displays to show the correct red and blue LED modes when set to logo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->