### PR TITLE
Add DMX setting to switch between single and two universes 

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -221,6 +221,7 @@ func (arena *Arena) LoadSettings() error {
 	if err = arena.Leds.SetAddress(settings.LedControllerAddress); err != nil {
 		return err
 	}
+	arena.Leds.SetUniverseMode(settings.LedUniverseMode)
 	arena.TbaClient = partner.NewTbaClient(settings.TbaEventCode, settings.TbaSecretId, settings.TbaSecret)
 	arena.NexusClient = partner.NewNexusClient(settings.TbaEventCode, settings.NexusAutoQueueKey)
 	arena.BlackmagicClient = partner.NewBlackmagicClient(settings.BlackmagicAddresses)

--- a/led/controller.go
+++ b/led/controller.go
@@ -41,8 +41,17 @@ func NewController() *Controller {
 	return &Controller{
 		redZone:   zone{currentMode: OffMode},
 		blueZone:  zone{currentMode: OffMode},
-		fixtures:  defaultFixtureLayout,
+		fixtures:  singleUniverseFixtureLayout,
 		universes: map[int]*universe{},
+	}
+}
+
+// SetUniverseMode configures the LED controller for single or dual universe operation.
+func (controller *Controller) SetUniverseMode(mode string) {
+	if mode == "two" {
+		controller.fixtures = twoUniverseFixtureLayout
+	} else {
+		controller.fixtures = singleUniverseFixtureLayout
 	}
 }
 

--- a/led/fixture.go
+++ b/led/fixture.go
@@ -45,13 +45,13 @@ var defaultFixtureLayout = fixtureLayout{
 		// Facing Driver Station.
 		{redGoalSide1Bot, 1, 1},
 		{redGoalSide1Top, 1, 25},
-		// Facing Audience.
+		// Facing Scoring Table.
 		{redGoalSide2Bot, 1, 49},
 		{redGoalSide2Top, 1, 73},
 		// Facing Center.
 		{redGoalSide3Bot, 1, 97},
 		{redGoalSide3Top, 1, 121},
-		// Facing Scoring Table.
+		// Facing Audience.
 		{redGoalSide4Bot, 1, 145},
 		{redGoalSide4Top, 1, 169},
 	},

--- a/led/fixture.go
+++ b/led/fixture.go
@@ -37,10 +37,9 @@ type fixtureLayout struct {
 	blue []fixture
 }
 
-// defaultFixtureLayout maps each 8-pixel fixture to a DMX universe and 1-based DMX start address.
-// To split the field across multiple universes, change the universe values below; the controller will
-// automatically assemble and send one packet per universe.
-var defaultFixtureLayout = fixtureLayout{
+// singleUniverseFixtureLayout maps each 8-pixel fixture to a DMX universe and 1-based DMX start address.
+// This is the default configuration for a single universe setup.
+var singleUniverseFixtureLayout = fixtureLayout{
 	red: []fixture{
 		// Facing Driver Station.
 		{redGoalSide1Bot, 1, 1},
@@ -68,5 +67,23 @@ var defaultFixtureLayout = fixtureLayout{
 		// Facing Scoring Table.
 		{blueGoalSide4Bot, 1, 337},
 		{blueGoalSide4Top, 1, 361},
+	},
+}
+
+var twoUniverseFixtureLayout = fixtureLayout{
+	red: singleUniverseFixtureLayout.red, // Red remains on Universe 1
+	blue: []fixture{
+		// Facing Driver Station.
+		{blueGoalSide1Bot, 2, 1},
+		{blueGoalSide1Top, 2, 25},
+		// Facing Audience.
+		{blueGoalSide2Bot, 2, 49},
+		{blueGoalSide2Top, 2, 73},
+		// Facing Center.
+		{blueGoalSide3Bot, 2, 97},
+		{blueGoalSide3Top, 2, 121},
+		// Facing Scoring Table.
+		{blueGoalSide4Bot, 2, 145},
+		{blueGoalSide4Top, 2, 169},
 	},
 }

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -70,6 +70,7 @@ type EventSettings struct {
 	SCCDownCommands                  string
 	PlcAddress                       string
 	LedControllerAddress             string
+	LedUniverseMode                  string
 	AdminPassword                    string
 	TeamSignRed1Id                   int
 	TeamSignRed2Id                   int
@@ -142,6 +143,7 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		ApChannel:                  36,
 		SCCUpCommands:              strings.Join(sccDefaultUpCommands, "\n"),
 		SCCDownCommands:            strings.Join(sccDefaultDownCommands, "\n"),
+		LedUniverseMode:            "single",
 		CompanionAddress:           "",
 		AutoDurationSec:            game.MatchTiming.AutoDurationSec,
 		PauseDurationSec:           game.MatchTiming.PauseDurationSec,

--- a/model/event_settings_test.go
+++ b/model/event_settings_test.go
@@ -30,6 +30,7 @@ func TestEventSettingsReadWrite(t *testing.T) {
 			SCCUpCommands:              "configure terminal\ninterface range gigabitEthernet 1/2-4\nno shutdown\nexit\nexit\nexit",
 			SCCDownCommands:            "configure terminal\ninterface range gigabitEthernet 1/2-4\nshutdown\nexit\nexit\nexit",
 			LedControllerAddress:       "",
+			LedUniverseMode:            "single",
 			AutoDurationSec:            20,
 			PauseDurationSec:           3,
 			TransitionShiftDurationSec: 10,

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -430,6 +430,15 @@ UI for configuring event settings.
                     value="{{.LedControllerAddress}}" placeholder="10.0.100.60">
                 </div>
               </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">Universe Mode</label>
+                <div class="col-lg-6">
+                  <select class="form-select" name="ledUniverseMode">
+                    <option value="single" {{if ne .LedUniverseMode "two"}}selected{{end}}>Single Universe</option>
+                    <option value="two" {{if eq .LedUniverseMode "two"}}selected{{end}}>Two Universes</option>
+                  </select>
+                </div>
+              </div>
             </fieldset>
             <fieldset class="mb-4">
               <legend>Driver Station Lite Mode</legend>

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -136,6 +136,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.SCCDownCommands = r.PostFormValue("sccDownCommands")
 	eventSettings.PlcAddress = r.PostFormValue("plcAddress")
 	eventSettings.LedControllerAddress = r.PostFormValue("ledControllerAddress")
+	eventSettings.LedUniverseMode = r.PostFormValue("ledUniverseMode")
 	eventSettings.AdminPassword = r.PostFormValue("adminPassword")
 	eventSettings.TeamSignRed1Id, _ = strconv.Atoi(r.PostFormValue("teamSignRed1Id"))
 	eventSettings.TeamSignRed2Id, _ = strconv.Atoi(r.PostFormValue("teamSignRed2Id"))

--- a/web/setup_settings_test.go
+++ b/web/setup_settings_test.go
@@ -36,7 +36,7 @@ func TestSetupSettings(t *testing.T) {
 		"/setup/settings",
 		"name=Chezy Champs&code=CC&playoffType=single&numPlayoffAlliances=16&tbaPublishingEnabled=on&"+
 			"tbaEventCode=2014cc&tbaSecretId=secretId&tbaSecret=tbasec&transitionShiftDurationSec=12&"+
-			"shiftDurationSec=24&endgameDurationSec=32&ledControllerAddress=10.0.100.61",
+			"shiftDurationSec=24&endgameDurationSec=32&ledControllerAddress=10.0.100.61&ledUniverseMode=two",
 	)
 	assert.Equal(t, 303, recorder.Code)
 	assert.Equal(t, "/setup/settings#event", recorder.Header().Get("Location"))
@@ -51,6 +51,7 @@ func TestSetupSettings(t *testing.T) {
 	assert.Equal(t, 24, web.arena.EventSettings.ShiftDurationSec)
 	assert.Equal(t, 32, web.arena.EventSettings.EndgameDurationSec)
 	assert.Equal(t, "10.0.100.61", web.arena.EventSettings.LedControllerAddress)
+	assert.Equal(t, "two", web.arena.EventSettings.LedUniverseMode)
 	assert.Equal(t, 140, game.GetTeleopDurationSec())
 
 	recorder = web.postHttpResponse("/setup/settings", "name=Field Tab Event&activeSettingsTab=field")


### PR DESCRIPTION
Adds DMX setting to switch between single and two universes.
This allows using both the configuration used at qualifying events as well as the configuration used at the championship.
<img width="829" height="191" alt="image" src="https://github.com/user-attachments/assets/88189001-d079-4b28-bab9-d34d91102c66" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Universe Mode setting for LED lighting.
  * Choose between Single Universe and Two Universes from Field settings.
  * The selected mode is saved and applied to LED controller configuration.
  * Single Universe is selected by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->